### PR TITLE
bugfix/cdn-build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@babel/preset-env": "^7.11.5",
         "@open-wc/eslint-config": "^3.0.0",
         "@open-wc/testing": "2.5.32",
+        "@rollup/plugin-alias": "^3.1.2",
         "@rollup/plugin-babel": "^5.2.3",
         "@rollup/plugin-commonjs": "^17.1.0",
         "@rollup/plugin-json": "^4.1.0",
@@ -3599,6 +3600,21 @@
       "peerDependencies": {
         "react": "15.x || 16.x || 16.4.0-alpha.0911da3",
         "react-dom": "15.x || 16.x || 16.4.0-alpha.0911da3"
+      }
+    },
+    "node_modules/@rollup/plugin-alias": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.2.tgz",
+      "integrity": "sha512-wzDnQ6v7CcoRzS0qVwFPrFdYA4Qlr+ookA217Y2Z3DPZE1R8jrFNM3jvGgOf6o6DMjbnQIn5lCIJgHPe1Bt3uw==",
+      "dev": true,
+      "dependencies": {
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -30280,7 +30296,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
       "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -30300,7 +30316,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
       "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -30308,7 +30324,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
       "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -30316,7 +30332,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
       "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -30335,7 +30351,7 @@
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -30359,7 +30375,7 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -48215,6 +48231,15 @@
         "invariant": "^2.2.3",
         "prop-types": "^15.6.1",
         "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "@rollup/plugin-alias": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.2.tgz",
+      "integrity": "sha512-wzDnQ6v7CcoRzS0qVwFPrFdYA4Qlr+ookA217Y2Z3DPZE1R8jrFNM3jvGgOf6o6DMjbnQIn5lCIJgHPe1Bt3uw==",
+      "dev": true,
+      "requires": {
+        "slash": "^3.0.0"
       }
     },
     "@rollup/plugin-babel": {
@@ -68097,7 +68122,7 @@
           "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
           "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -68115,21 +68140,21 @@
           "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
           "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
           "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
           "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -68146,7 +68171,7 @@
           "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
           "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -68167,7 +68192,7 @@
           "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
           "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "test": "wtr src/**/*.test.ts",
     "test:watch": "wtr src/**/*.test.ts --watch",
     "test:playwright": "wtr src/**/*.test.ts --playwright --browsers chromium firefox webkit",
-    "prepack": "npm run lint && rimraf dist && ttsc && node postbuild.js && rollup -c && npm run cpx",
-    "tmpbuild": "rimraf dist && ttsc && node postbuild.js && rollup -c"
+    "prepack": "npm run lint && rimraf dist && ttsc && node postbuild.js && rollup -c && npm run cpx"
   },
   "dependencies": {
     "@foxy.io/sdk": "^1.0.0-beta.14",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test": "wtr src/**/*.test.ts",
     "test:watch": "wtr src/**/*.test.ts --watch",
     "test:playwright": "wtr src/**/*.test.ts --playwright --browsers chromium firefox webkit",
-    "prepack": "npm run lint && rimraf dist && ttsc && node postbuild.js && rollup -c && npm run cpx"
+    "prepack": "npm run lint && rimraf dist && ttsc && node postbuild.js && rollup -c && npm run cpx",
+    "tmpbuild": "rimraf dist && ttsc && node postbuild.js && rollup -c"
   },
   "dependencies": {
     "@foxy.io/sdk": "^1.0.0-beta.14",
@@ -52,6 +53,7 @@
     "@babel/preset-env": "^7.11.5",
     "@open-wc/eslint-config": "^3.0.0",
     "@open-wc/testing": "2.5.32",
+    "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-babel": "^5.2.3",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-json": "^4.1.0",

--- a/postbuild.js
+++ b/postbuild.js
@@ -16,7 +16,10 @@ console.log('[tailwindcss]: build started');
     Object.assign({}, require('./tailwind.config.js'), {
       purge: {
         enabled: true,
-        content: ['./src/**/*.*'],
+        content: ['./src/**/*.ts'],
+        options: {
+          whitelistPatterns: [/:host/],
+        },
       },
     })
   );

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import alias from '@rollup/plugin-alias';
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import multiInput from 'rollup-plugin-multi-input';
@@ -18,6 +19,14 @@ export default {
     multiInput({
       relative: 'dist/elements/public',
       transformOutputPath: output => `foxy-${paramCase(path.dirname(output))}.js`,
+    }),
+    alias({
+      entries: [
+        {
+          find: /@foxy\.io\/sdk\/(.*)/,
+          replacement: '@foxy.io/sdk/dist/esm/$1',
+        },
+      ],
     }),
     nodeResolve({ browser: true }),
     commonjs(),

--- a/src/elements/public/CustomersTable/index.ts
+++ b/src/elements/public/CustomersTable/index.ts
@@ -1,3 +1,4 @@
+import '../Spinner/index';
 import '../I18n/index';
 
 import { CustomersTable } from './CustomersTable';

--- a/src/elements/public/SubscriptionsTable/index.ts
+++ b/src/elements/public/SubscriptionsTable/index.ts
@@ -1,3 +1,4 @@
+import '../Spinner/index';
 import '../I18n/index';
 
 import { SubscriptionsTable } from './SubscriptionsTable';

--- a/src/elements/public/TransactionsTable/index.ts
+++ b/src/elements/public/TransactionsTable/index.ts
@@ -1,3 +1,4 @@
+import '../Spinner/index';
 import '../I18n/index';
 
 import { TransactionsTable } from './TransactionsTable';


### PR DESCRIPTION
This PR fixes CDN builds for new elements. In particular, it adds Rollup aliases for the conditional imports in our SDK so that it's bundled correctly, fixes PurgeCSS config to keep responsive variants in the final build, and adds a few missing imports to the table elements.