### PR TITLE
fix(foxy-donation): "other" option text input change event

### DIFF
--- a/src/elements/private/Choice/Choice.ts
+++ b/src/elements/private/Choice/Choice.ts
@@ -271,16 +271,16 @@ export class Choice extends Translatable {
 
   private get __field() {
     const handleInput = (evt: Event) => {
-      if (evt.type === 'change') {
-        evt.stopPropagation();
-        const customValue = (evt.target as HTMLInputElement).value;
-        if (Array.isArray(this.value)) {
-          this.value = this.value.slice(0, this.value.length - 1).concat(customValue);
-        } else {
-          this.value = customValue;
-        }
-        this.dispatchEvent(new ChoiceChangeEvent(this.value));
+      evt.stopPropagation();
+      const customValue = (evt.target as HTMLInputElement).value;
+
+      if (Array.isArray(this.value)) {
+        this.value = this.value.slice(0, this.value.length - 1).concat(customValue);
+      } else {
+        this.value = customValue;
       }
+
+      this.dispatchEvent(new ChoiceChangeEvent(this.value));
     };
 
     const attributes = spread({
@@ -290,7 +290,6 @@ export class Choice extends Translatable {
       max: this.max,
       min: this.min,
       'data-testid': 'field',
-      '@input': handleInput,
       '@change': handleInput,
     });
 

--- a/src/elements/private/Choice/Choice.ts
+++ b/src/elements/private/Choice/Choice.ts
@@ -271,16 +271,16 @@ export class Choice extends Translatable {
 
   private get __field() {
     const handleInput = (evt: Event) => {
-      evt.stopPropagation();
-      const customValue = (evt.target as HTMLInputElement).value;
-
-      if (Array.isArray(this.value)) {
-        this.value = this.value.slice(0, this.value.length - 1).concat(customValue);
-      } else {
-        this.value = customValue;
+      if (evt.type === 'change') {
+        evt.stopPropagation();
+        const customValue = (evt.target as HTMLInputElement).value;
+        if (Array.isArray(this.value)) {
+          this.value = this.value.slice(0, this.value.length - 1).concat(customValue);
+        } else {
+          this.value = customValue;
+        }
+        this.dispatchEvent(new ChoiceChangeEvent(this.value));
       }
-
-      this.dispatchEvent(new ChoiceChangeEvent(this.value));
     };
 
     const attributes = spread({


### PR DESCRIPTION
The change event was being sent upon input, causing the element to
switch from "other" into one of the presets when the user was still
  typing. The element will now only send a change event when the input
  event is of type change, allowing the user to finish typing.

  fix #36