### PR TITLE
fix(foxy-donation): allow custom store domains

### DIFF
--- a/src/elements/public/Donation/Donation.test.ts
+++ b/src/elements/public/Donation/Donation.test.ts
@@ -50,6 +50,29 @@ describe('foxy-donation', () => {
       });
     });
 
+    describe('store domains', () => {
+      it('supports partial store domains', async () => {
+        const layout = `<foxy-donation currency="usd" amount="25" store="foxy-demo" name="Donation"></foxy-donation>`;
+        const element = await fixture<Donation>(layout);
+
+        expect(getRefs<Refs>(element).form?.action).to.equal('https://foxy-demo.foxycart.com/cart');
+      });
+
+      it('supports full store domains', async () => {
+        const layout = `<foxy-donation currency="usd" amount="25" store="foxy-demo.foxycart.com" name="Donation"></foxy-donation>`;
+        const element = await fixture<Donation>(layout);
+
+        expect(getRefs<Refs>(element).form?.action).to.equal('https://foxy-demo.foxycart.com/cart');
+      });
+
+      it('supports custom store domains', async () => {
+        const layout = `<foxy-donation currency="usd" amount="25" store="example.com" name="Donation"></foxy-donation>`;
+        const element = await fixture<Donation>(layout);
+
+        expect(getRefs<Refs>(element).form?.action).to.equal('https://example.com/cart');
+      });
+    });
+
     describe('submission', () => {
       it('emits cancelable "submit" event on .submit()', async () => {
         const element = await fixture<Donation>(layout);

--- a/src/elements/public/Donation/Donation.ts
+++ b/src/elements/public/Donation/Donation.ts
@@ -94,8 +94,9 @@ export class Donation extends Translatable {
   public amount: null | number = null;
 
   /**
-   * **Required** store subdomain. This is usually the part after before `.foxycart.com`
+   * **Required** store domain. This is usually the part after before `.foxycart.com`
    * and after `https://`, e.g. the `foxy-demo` bit of `https://foxy-demo.foxycart.com`.
+   * Custom domains like `my.domain.example.com` are also supported since v1.6.1.
    *
    * **Example:** `"foxy-demo"`
    */
@@ -254,12 +255,14 @@ export class Donation extends Translatable {
       `;
     }
 
+    const domain = this.store.includes('.') ? this.store : `${this.store}.foxycart.com`;
+
     return html`
       <form
         target="${this.target}"
         class="sr-only"
         method="POST"
-        action="https://${this.store}.foxycart.com/cart"
+        action="https://${domain}/cart"
         data-testid="form"
       >
         ${[...this.__data.entries()].map(


### PR DESCRIPTION
This PR adds support for custom store domains to the `foxy-donation` element. Starting with this update, developers will be able to use both partial (`foxy-demo`) and full (`foxy-demo.foxycart.com`) domains, including custom ones (`my.domain.example.com`) in the `store` attribute of the donation form.

Closes #58