### PR TITLE
docs: add contribution guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# How to Contribute
+
+_Elements is a UI library built by [Foxy](https://www.foxy.io/about-us). If you see someone on the team mention "Foxy Elements", "Elements", "foxy-elements", "@foxy.io/elements", "elements package" or "elements repo", they're most likely referring to this project. We hope this document makes the process for contributing clear and answers some questions that you may have._
+
+## Code of Conduct
+
+Foxy has adopted the [Contributor Covenant](https://www.contributor-covenant.org/) as its Code of Conduct, and we expect project participants to adhere to it. Please read [the full text](CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
+
+## Open Development
+
+All work on Elements happens directly on [GitHub](https://github.com/Foxy/foxy-elements). Both team members and external contributors send pull requests which go through the same review process. In the same time, Elements is **not** a community-driven project, so we will always prioritize our own needs and the needs of our customers when it comes to feature requests.
+
+## Semantic Versioning
+
+Elements follow [semantic versioning](https://semver.org/). We release patch versions for bug fixes, minor versions for backwards-compatible features, and major versions for any breaking changes. Significant changes may also appear in a pre-release before they become generally available. Release notes are available on [this page](https://github.com/Foxy/foxy-elements/releases).
+
+## Branch Organization
+
+We have two release branches: [main](https://github.com/Foxy/foxy-elements/tree/main) and [beta](https://github.com/Foxy/foxy-elements/tree/beta). Whenever someone commits changes to them, GitHub Workflows create a release and publish it to npm almost immediately. Only stable, tested and reviewed code is allowed on main. Unstable, untested or not yet reviewed code may appear on beta. If your code breaks the build or causes serious runtime errors, please keep it in a separate branch until it's ready.
+
+## Bugs
+
+We are using [GitHub Issues](https://github.com/Foxy/foxy-elements/issues) for our public bugs. We keep a close eye on this and try to make it clear when we have an internal fix in progress. Before filing a new task, try to make sure your problem doesn’t already exist. If you've come across a security issue in this project, please consider [letting us know](https://www.foxy.io/security-contact) before opening a public issue.
+
+## How to Get in Touch
+
+You can find all the ways you can contact us on [this page](https://www.foxy.io/contact).
+
+## Proposing a Change
+
+If you intend to change the public API, or make any non-trivial changes to the implementation, we recommend filing an issue. This lets us reach an agreement on your proposal before you put significant effort into it.
+
+If you’re only fixing a bug, it’s fine to submit a pull request right away but we still recommend to file an issue detailing what you’re fixing. This is helpful in case we don’t accept that specific fix but want to keep track of the issue.
+
+## Your First Pull Request
+
+Working on your first pull request? You can learn how from [this free video series](https://app.egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github).
+
+If you decide to fix an issue, please be sure to check the comment thread and the list of assignees in case somebody is already working on a fix. If nobody is working on it at the moment, please leave a comment stating that you intend to work on it so other people don’t accidentally duplicate your effort.
+
+## Sending a Pull Request
+
+The team is monitoring for pull requests. We will review your pull request and either merge it, request changes to it, or close it with an explanation. We might also decide to keep it open to make sure your changes align with the internal roadmap for other Foxy products. In any case, we’ll do our best to provide updates and feedback throughout the process.
+
+Before submitting a pull request, please make sure the following is done:
+
+0. If you don't have write access, fork [the repository](https://github.com/Foxy/foxy-elements).
+1. Create your branch from `main`.
+2. Run `npm install` in the repository root.
+3. If you’ve fixed a bug or added code that should be tested, add tests.
+4. If you’ve changed the public interface, run `npm run wca` and commit changes in `custom-elements.json`.
+5. Ensure the test suite passes (`npm test`). Tip: `./node_modules/.bin/wtr TestPattern --watch` is helpful in development.
+6. Run `npm run prepack` and `npm run build:storybook` to test that your code doesn't break the build.
+7. Format your code with prettier (`npm run format`). Make sure your code lints.
+8. If you haven’t already, complete the CLA.
+
+## Contributor License Agreement (CLA)
+
+In order to accept your pull request, we need you to submit a CLA. You only need to do this once, and a bot will send you a reminder in case you forget. [Complete your CLA here](https://cla-assistant.io/Foxy/foxy-elements).
+
+## Tech We Use
+
+Each UI component in this library is a custom element based on LitElement. Our design system is built on Vaadin 14 with a set of custom TailwindCSS utilities providing shortcuts for Lumo colors, fonts, sizing and spacing. Translations are handled through i18next. We use Web Dev Server with Storybook for development, Web Test Runner for testing, Rollup for CDN builds and a custom TypeScript compiler for npm releases. Code style is enforced with Prettier and ESLint, commit style is maintained with Commitizen. We develop using [Git](https://git-scm.com/), [Node](https://nodejs.org/) v14+ and [npm](https://github.com/npm/cli) v7+.
+
+## Development Workflow
+
+After cloning Elements, run `npm install` to fetch the dependencies. Then, you can run several commands:
+
+- `npm run wca` regenerates `custom-elements.json` where all elements are documented.
+- `npm run storybook` launches Storybook with Web Dev Server.
+- `npm run storybook:build` builds Storybook with Rollup.
+- `npm run lint` checks the code style with both ESLint and Prettier.
+- `npm run lint:eslint` checks the code style with ESLint only.
+- `npm run lint:prettier` checks the code style with Prettier only.
+- `npm run format` fixes code style issues with both ESLint and Prettier.
+- `npm run format:eslint` fixes code style issues with ESLint only.
+- `npm run format:prettier` fixes code style issues with Prettier only.
+- `npm run test` runs the complete test suite.
+- `npm run test:watch` runs an interactive test watcher.
+- `npm run test:playwright` runs tests in major browsers with Playwright (experimental).
+- `npm run prepack` creates a `dist` folder for npm distribution.
+
+## Style Guide
+
+We use an automatic code formatter called [Prettier](https://prettier.io/). Run `npm run format:prettier` after making any changes to the code. Then, our linter will catch most issues that may exist in your code. You can check the status of your code styling by running `npm run lint:prettier`.
+
+## License
+
+By contributing to Elements, you agree that your contributions will be licensed under its [MIT license](LICENSE).
+
+## Useful Links
+
+- [Adding an Element](wiki/adding-an-element.md)
+- [Codebase Overview](wiki/codebase-overview.md)
+- [Mixins](wiki/mixins.md)
+- [Mock Server](wiki/mock-server.md)
+- [Foxy Elements Docs](https://elements.foxy.dev)
+- [Foxy SDK Docs](https://sdk.foxy.dev)

--- a/wiki/adding-an-element.md
+++ b/wiki/adding-an-element.md
@@ -1,0 +1,145 @@
+# Adding an Element
+
+This page will guide you through the process of adding a new element to the library, explain the existing conventions and provide helpful tips along the way.
+
+## File Structure
+
+Think of a name for your new element. As a convention, we categorize them into 4 groups: cards (name ends with "card"), forms ("form"), tables ("table") and other (no suffix). The main part of the name is usually a [hAPI relation](https://api.foxycart.com/docs/reference) like `custom_field`. Convert that name to PascalCase and create the following folder structure (we'll be using custom field as an example here and below):
+
+```text
+src/elements/public/CustomFieldForm
+  CustomFieldForm.ts          # element class
+  CustomFieldForm.stories.ts  # storybook docs
+  CustomFieldForm.test.ts     # tests
+  types.ts                    # shared type definitions
+  index.ts                    # element(s) registration
+```
+
+## Shared Type Definitions
+
+Construct the data type of your element in `types.ts`. Most of the time you'll be able to find your resource under the [Rels](https://github.com/Foxy/foxy-sdk/blob/main/src/backend/Rels.d.ts) namespace of the Backend SDK. You should prefer the relations exported from the Backend namespace since other namespaces usually export a subset of it anyway.
+
+```ts
+import { Resource } from '@foxy.io/sdk/core';
+import { Rels } from '@foxy.io/sdk/backend';
+
+export type Data = Resource<Rels.CustomField>;
+```
+
+If you need to add other shared type definitions, it's a good idea to put them into this file as well for consistency with other elements.
+
+## Element Class
+
+Use the data type to create a basic element class in `CustomFieldForm.ts`. If you're working with hAPI resources, you'll want to use [NucleonElement](https://github.com/Foxy/foxy-elements/tree/main/src/elements/public/NucleonElement) since it comes with a lot of [useful functionality](https://elements.foxy.dev/?path=/story/other-nucleon--page) for state management and editing. Note how we import `NucleonElement` and not `index` from the element folder since the latter comes with a side effect of defining an element in a global registry.
+
+```ts
+import { NucleonElement } from '../NucleonElement/NucleonElement';
+import { Data } from './types';
+
+/**
+ * Form element for creating or editing `fx:custom_field` resources.
+ *
+ * @element foxy-custom-field-form
+ * @since 1.11.0
+ */
+export class CustomFieldForm extends NucleonElement<Data> {}
+```
+
+If your element doesn't work with hAPI, it's ok to extend `LitElement` directly instead. You can also extend other elements if it makes sense. Don't forget about [JSDoc](https://github.com/runem/web-component-analyzer#-how-to-document-your-components-using-jsdoc) – it turns into a nicely formatted API reference in Storybook once you run `npm run wca`.
+
+## Element(s) Registration
+
+Import your element in `index.ts`, define and re-export the class. Local name is "foxy" + your class name in kebab-case. If you're using a 3rd-party element that automatically defines itself (like `iron-icon`), place its import in `index.ts` as well. We separate definition from registration to support side effect-free inheritance and [scoped element registries](https://open-wc.org/docs/development/scoped-elements).
+
+```ts
+import { CustomFieldForm } from './CustomFieldForm';
+
+customElements.define('foxy-custom-field-form', CustomFieldForm);
+
+export { CustomFieldForm };
+```
+
+## Storybook Docs
+
+Import `index.ts` in `CustomFieldForm.stories.ts` and bootstrap the story using our generators and mock server. This is a standard [Storybook CSF file](https://storybook.js.org/docs/web-components/api/csf), so feel free to skip our utilities and use the format directly. Start with the four stories from the code snippet below and add more if necessary.
+
+```ts
+import './index'; // Automatically define the element
+
+import { Summary } from '../../../storygen/Summary';
+import { getMeta } from '../../../storygen/getMeta';
+import { getStory } from '../../../storygen/getStory';
+
+const summary: Summary = {
+  // Mock URL of a standalone resource (see Mock server)
+  href: 'https://demo.foxycart.com/s/admin/custom_fields/0',
+
+  // Mock URL of a collection that standalone resource belongs to (see Mock server)
+  parent: 'https://demo.foxycart.com/s/admin/transactions/0/custom_fields',
+
+  // Always true for elements based on NucleonElement
+  nucleon: true,
+
+  // The tag you've your element with
+  localName: 'foxy-custom-field-form',
+
+  // Set to true if your element uses TranslatableMixin (see Mixins section)
+  translatable: false,
+
+  // Set to true if your element uses ConfigurableMixin (see Mixins section)
+  configurable: false,
+};
+
+// Story metadata automatically generated from the summary above
+export default getMeta(summary);
+
+// Story displaying the element in the `idle.snapshot.clean` state + a code snippet
+export const Playground = getStory({ ...summary, code: true });
+
+// Story displaying the element in the `idle.template.clean` state
+export const Empty = getStory(summary);
+Empty.args.href = '';
+
+// Story displaying the element in the `fail` state
+export const Error = getStory(summary);
+Error.args.href = 'https://demo.foxycart.com/s/admin/not-found';
+
+// Story displaying the element in the `busy` state
+export const Busy = getStory(summary);
+Busy.args.href = 'https://demo.foxycart.com/s/admin/sleep';
+```
+
+To see your stories in action, run `npm run storybook`.
+
+## Package Exports
+
+Expose the newly added element via `index.ts` and `index.defined.ts`. This adds your element to the two main library exports available to npm users.
+
+```ts
+// src/elements/public/index.ts
+export { CustomFieldForm } from './CustomFieldForm/CustomFieldForm';
+```
+
+```ts
+// src/elements/public/index.defined.ts
+export { CustomFieldForm } from './CustomFieldForm/index';
+```
+
+## Tests
+
+Writing tests is perhaps the most standard thing out of all in Elements. See [Web Test Runner guides](https://modern-web.dev/guides/test-runner/getting-started/) for a detailed intro to the approach and tech stack. Here's an example of what a good starting point could look like for `CustomFieldForm.test.ts`:
+
+```ts
+import { expect } from '@open-wc/testing';
+import { CustomFieldForm } from './index';
+
+it('defines a custom element tagged "foxy-custom-field-form"', () => {
+  expect(customElements.get('foxy-custom-field-form')).to.equal(CustomFieldForm);
+});
+```
+
+To test your changes, run `npm test` or `npm run test:watch` (the latter re-runs the tests on save). Running the whole test suite might take a while, so you might want to limit yourself to just one file while developing:
+
+```bash
+./node_modules/.bin/wtr **/CustomFieldForm.test.ts --watch
+```

--- a/wiki/codebase-overview.md
+++ b/wiki/codebase-overview.md
@@ -1,0 +1,41 @@
+# Codebase Overview
+
+This section will give you an overview of the Elements codebase organization, its conventions, and the implementation.
+
+## Top-Level
+
+- [.build](../.build) - custom TypeScript compiler and bundler plugins.
+- [.github](../.github) - GitHub Workflows for PRs and releases.
+- [.storybook](../.storybook) - Storybook configuration.
+
+## Source (`/src`)
+
+- [elements](../src/elements) - all custom elements in the library.
+  - [internal](../src/elements/internal) - custom elements for internal use in global registry, grouped by class name.
+  - [private](../src/elements/private) - custom elements for internal use in scoped registries, grouped by class name.
+  - [public](../src/elements/public) - custom elements for public use, grouped by class name.
+- [events](../src/events) - common events (deprecated).
+- [global](../src/global) - JS globals (deprecated).
+- [mixins](../src/mixins) - various [mixins](./mixins.md) for internal use.
+- [mocks](../src/mocks) - hAPI and i18next data for testing (deprecated).
+- [server](../src/server) - [mock server](./mock-server.md) for demo and test purposes.
+- [static](../src/static) - static files like images and translations.
+- [storygen](../src/storygen) - story generation utilities for Storybook.
+- [testgen](../src/testgen) - various test helpers.
+- [types](../src/types) - common type definitions and augmentations for packages without type info.
+- [utils](../src/utils) - shared utilities.
+- [env.ts](../src/env.ts) - `process.env` config (deprecated).
+- [index.defined.ts](../src/index.defined.ts) - library export that defines custom elements on import.
+- [index.ts](../src/index.ts) - main library export (bare element classes).
+
+## Translations (`/src/static/translations`)
+
+- [admin](../src/static/translations/admin) - i18n files for the Foxy Admin (deprecated).
+- [country](../src/static/translations/country) - localized country names (deprecated).
+- [customer-portal](../src/static/translations/customer-portal) - translations specific to the [Customer Portal](../src/elements/public/CustomerPortal).
+- [customer-portal-settings](../src/static/translations/customer-portal-settings) - translations specific to the [Customer Portal Settings](../src/elements/public/CustomerPortalSettings).
+- [donation](../src/static/translations/donation) - translations specific to the [Donation Form](../src/elements/public/DonationForm).
+- [global](../src/static/translations/global) - common translations for pre-Nucleon elements (deprecated).
+- [items-form](../src/static/translations/items-form) - translations specific to the [Items Form](../src/elements/public/ItemsForm).
+- [region](../src/static/translations/region) - localized region names (deprecated).
+- [shared](../src/static/translations/shared) - common translations, fallbacks.

--- a/wiki/mixins.md
+++ b/wiki/mixins.md
@@ -1,0 +1,232 @@
+# Mixins
+
+Some of the core functionality of our elements is available in form of [mixins](https://www.typescriptlang.org/docs/handbook/mixins.html), making it possible to opt into it only when you actually need it. This page will give you a quick tour around what's in store.
+
+## ThemeableMixin
+
+We use [TailwindCSS](https://tailwindcss.com) to generate utility classes for the [Lumo Design System](https://demo.vaadin.com/lumo-editor) that comes with [Vaadin 14](https://vaadin.com/docs/v14/guide/introduction). If you'd like to use them, simply apply this mixin to your element. Remember to always use full utility names to prevent [PurgeCSS](https://purgecss.com) from removing their CSS from the production build. If you need to use responsive styles, apply `ResponsiveMixin` as well.
+
+```ts
+import { ThemeableMixin } from '../../../mixins/themeable';
+import { NucleonElement } from '../NucleonElement/NucleonElement';
+import { html } from 'lit-element';
+import { Data } from './types';
+
+export class CustomFieldForm extends ThemeableMixin(NucleonElement)<Data> {
+  render() {
+    return html`<div class="text-primary font-lumo">Foo</div>`;
+  }
+}
+```
+
+## ResponsiveMixin
+
+This mixin tracks the element size with [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) and adds the applicable breakpoints to an attribute, allowing you to use responsive utilities from `ThemeableMixin` or target specific container sizes with the [:host()](<https://developer.mozilla.org/en-US/docs/Web/CSS/:host()>) function. Just like [CSS Container Queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries), but now and supported in all major browsers.
+
+```ts
+import { ResponsiveMixin } from '../../../mixins/themeable';
+import { ThemeableMixin } from '../../../mixins/themeable';
+import { NucleonElement } from '../NucleonElement/NucleonElement';
+import { html } from 'lit-element';
+import { Data } from './types';
+
+export class CustomFieldForm extends ResponsiveMixin(ThemeableMixin(NucleonElement))<Data> {
+  render() {
+    return html`<div class="text-s md-text-m lg-text-l">Foo</div>`;
+  }
+}
+```
+
+## TranslatableMixin
+
+Apply this mixin to make your element translatable with [i18next](https://www.i18next.com). Use your class name in kebab-case as namespace (second argument). Add translations under `src/static/translations/${namespace}/${lang}.json`. Add as much as you can to "shared" first, and if there's something specific to this particular element, use your own namespace.
+
+```ts
+import { TranslatableMixin } from '../../../mixins/translatable';
+import { NucleonElement } from '../NucleonElement/NucleonElement';
+import { html } from 'lit-element';
+import { Data } from './types';
+
+export class CustomFieldForm extends TranslatableMixin(NucleonElement, 'custom-field-form')<Data> {
+  render() {
+    return html`<div lang=${this.lang}>${this.t('name')}</div>`;
+  }
+}
+```
+
+## ConfigurableMixin
+
+We strive to make each and every one of our components as configurable as possible. Sometimes our customers want to hide specific controls, sometimes they need to make them read-only or disabled in certain circumstances, and sometimes they ask us if it's possible to add some content in a completely unexpected place. This mixin provides a flexible API based on [BooleanSelector](https://sdk.foxy.dev/classes/_core_index_.booleanselector.html) catering to all of these scenarios.
+
+### Hide, Disable, Make Readonly
+
+```ts
+import { ConfigurableMixin } from '../../../mixins/configurable';
+import { NucleonElement } from '../NucleonElement/NucleonElement';
+import { html } from 'lit-element';
+import { Data } from './types';
+
+export class CustomFieldForm extends ConfigurableMixin(NucleonElement)<Data> {
+  render() {
+    // use .disabledSelector to toggle parts of your elements on and off
+    // use .readonlySelector to control which parts of your elements are editable
+    // use .hiddenSelector to hide parts of your elements
+
+    const isNameDisabled = this.disabledSelector.matches('name', true);
+    const isValueDisabled = this.disabledSelector.matches('value', true);
+
+    return html`
+      <label>Name: <input ?disabled=${isNameDisabled} /></label>
+      <label>Value: <input ?disabled=${isValueDisabled} /></label>
+    `;
+  }
+}
+```
+
+```html
+<!-- Disable all inputs in a form -->
+<foxy-custom-field-form disabled></foxy-custom-field-form>
+<foxy-custom-field-form disabledcontrols="name value"></foxy-custom-field-form>
+
+<!-- Disable only the name input -->
+<foxy-custom-field-form disabledcontrols="name"></foxy-custom-field-form>
+<foxy-custom-field-form disabledcontrols=":not=value"></foxy-custom-field-form>
+```
+
+### Add Custom Content
+
+```ts
+import { ConfigurableMixin } from '../../../mixins/configurable';
+import { NucleonElement } from '../NucleonElement/NucleonElement';
+import { html } from 'lit-element';
+import { Data } from './types';
+
+export class CustomFieldForm extends ConfigurableMixin(NucleonElement)<Data> {
+  render() {
+    return html`
+      <div>
+        <span>${this.renderTemplateOrSlot('title:before')}</span>
+        <span>Custom field form title</span>
+        <span>${this.renderTemplateOrSlot('title:after')}</span>
+      </div>
+    `;
+  }
+}
+```
+
+```html
+<foxy-custom-field-form>
+  <template slot="title:before">Dynamic prefix for ${host.data.name}</template>
+  <div slot="title:after">Static suffix for a custom field</div>
+</foxy-custom-field-form>
+```
+
+### Conventions
+
+Surround every configurable control with `:before` and `:after` templates. Hiding the control should hide the templates as well. Here's what it might look like in your template:
+
+```ts
+import { ConfigurableMixin } from '../../../mixins/configurable';
+import { NucleonElement } from '../NucleonElement/NucleonElement';
+import { html } from 'lit-element';
+import { Data } from './types';
+
+export class CustomFieldForm extends ConfigurableMixin(NucleonElement)<Data> {
+  render() {
+    if (this.hiddenSelector.matches('name', true)) return;
+
+    const isNameDisabled = this.disabledSelector.matches('name', true);
+    const isNameReadonly = this.readonlySelector.matches('name', true);
+
+    return html`
+      ${this.renderTemplateOrSlot('name:before')}
+      <input ?disabled=${isNameDisabled} ?readonly=${isNameReadonly} />
+      ${this.renderTemplateOrSlot('name:after')}
+    `;
+  }
+}
+```
+
+### Deep Configurations
+
+When using other configurable elements in your code, don't forget to pass the configuration to them like so:
+
+```ts
+import { ConfigurableMixin } from '../../../mixins/configurable';
+import { NucleonElement } from '../NucleonElement/NucleonElement';
+import { html } from 'lit-element';
+import { Data } from './types';
+
+export class CustomFieldForm extends ConfigurableMixin(NucleonElement)<Data> {
+  render() {
+    return html`
+      <foxy-attribute-form
+        disabledcontrols=${this.disabledSelector.zoom('form').toString()}
+        readonlycontrols=${this.readonlySelector.zoom('form').toString()}
+        hiddencontrols=${this.hiddenSelector.zoom('form').toString()}
+        .templates=${this.getNestedTemplates('form')}
+      >
+      </foxy-attribute-form>
+    `;
+  }
+}
+```
+
+```html
+<foxy-custom-field-form hiddencontrols="form:timestamps" readonlycontrols="form:not=value">
+  <template slot="form:name:before">Dynamic prefix for ${host.data.name}</template>
+</foxy-custom-field-form>
+```
+
+### Documenting Controls
+
+Step 1: add `Templates` type definition to the `types.ts` file in your element folder. Describe each template like below using the `Renderer` generic from the configurable mixin file:
+
+```ts
+import { Renderer } from '../../../mixins/configurable';
+import { CustomFieldForm } from './CustomFieldForm';
+
+export type Templates = {
+  'name:before'?: Renderer<CustomFieldForm>;
+  'name:after'?: Renderer<CustomFieldForm>;
+  'value:before'?: Renderer<CustomFieldForm>;
+  'value:after'?: Renderer<CustomFieldForm>;
+};
+```
+
+Step 2: add [JSDoc](https://github.com/runem/web-component-analyzer#-how-to-document-your-components-using-jsdoc) for each one of the templates using the `@slot` tag:
+
+```ts
+import { ConfigurableMixin } from '../../../mixins/configurable';
+import { NucleonElement } from '../NucleonElement/NucleonElement';
+import { Data } from './types';
+
+/**
+ * Form element for creating or editing `fx:custom_field` resources.
+ *
+ * @slot name:before
+ * @slot name:after
+ *
+ * @slot value:before
+ * @slot value:after
+ *
+ * @element foxy-custom-field-form
+ * @since 1.11.0
+ */
+export class CustomFieldForm extends ConfigurableMixin(NucleonElement)<Data> {}
+```
+
+Step 3: explicitly specify the type on a property in your element class:
+
+```ts
+import { ConfigurableMixin } from '../../../mixins/configurable';
+import { NucleonElement } from '../NucleonElement/NucleonElement';
+import { Data, Templates } from './types';
+
+/** [collapsed] */
+export class CustomFieldForm extends ConfigurableMixin(NucleonElement)<Data> {
+  templates: Templates = {};
+}
+```
+
+Don't forget to run `npm run wca` when you're done to update `custom-elements.json`.

--- a/wiki/mock-server.md
+++ b/wiki/mock-server.md
@@ -1,0 +1,91 @@
+# Mock Server
+
+This is an experimental technology that we use to test our elements and demo them in Storybook. In essence, every time an element makes a request, it sends out a DOM event of type `fetch`. Our mock server listens to those events, cancels the network calls and responds to them with the data from IndexedDB. Refreshing the page resets the database. This concept is also explained in the [NucleonElement docs](https://elements.foxy.dev/?path=/story/other-nucleon--page) under Request Interception.
+
+Since mock server is more of an internal tool than a product we'd offer to our customers, we can't spend too much time on making it perfect. We don't write docs or tests for it, we don't care if it doesn't behave exactly like hAPI in every scenario, and we don't enforce type safety or style guidelines in its code. The following endpoints are available so far:
+
+## Customer API
+
+Mock Customer API works a lot like [the real one](https://wiki.foxycart.com/v/2.0/customer_portal) with `FOXY-API-VERSION` header set to `1`. It has the authentication and the URL format is exactly the same. We use it to demo and test our latest Customer Portal:
+
+```text
+https://demo.foxycart.com/s/customer/authenticate POST, DELETE
+https://demo.foxycart.com/s/customer/addresses/0 GET, PATCH, DELETE
+https://demo.foxycart.com/s/customer/addresses GET
+https://demo.foxycart.com/s/customer/customer_portal_settings GET
+https://demo.foxycart.com/s/customer/default_payment_method GET
+https://demo.foxycart.com/s/customer/forgot_password POST
+https://demo.foxycart.com/s/customer GET, PATCH
+https://demo.foxycart.com/s/customer/subscriptions/0 GET, PATCH
+https://demo.foxycart.com/s/customer/subscriptions GET
+https://demo.foxycart.com/s/customer/transactions GET
+```
+
+## Backend API
+
+Mock Backend API is like [hAPI](https://api.foxycart.com), but with half (third? quarter?) of the functionality and no authentication. We use it to demo and test individual elements like cards and forms:
+
+```text
+https://demo.foxycart.com/s/admin/customers/0/default_payment_method GET, DELETE
+https://demo.foxycart.com/s/admin/customers/0/attributes GET, POST
+https://demo.foxycart.com/s/admin/customers/0/addresses GET, POST
+
+https://demo.foxycart.com/s/admin/stores/0/subscriptions GET
+https://demo.foxycart.com/s/admin/stores/0/error_entries GET
+https://demo.foxycart.com/s/admin/stores/0/transactions GET
+https://demo.foxycart.com/s/admin/stores/0/customers GET, PATCH, DELETE
+https://demo.foxycart.com/s/admin/stores/0/users GET, POST
+
+https://demo.foxycart.com/s/admin/transactions/0 GET
+https://demo.foxycart.com/s/admin/transactions/0/custom_fields GET, POST
+
+https://demo.foxycart.com/s/admin/customer_attributes/0 GET, PATCH, DELETE
+https://demo.foxycart.com/s/admin/customer_addresses/0 GET, PATCH, DELETE
+https://demo.foxycart.com/s/admin/subscriptions/0 GET, PATCH
+https://demo.foxycart.com/s/admin/error_entries/0 GET, PATCH
+https://demo.foxycart.com/s/admin/custom_fields/0 GET, PATCH, DELETE
+https://demo.foxycart.com/s/admin/items/0 GET
+https://demo.foxycart.com/s/admin/users/0 GET, PATCH, DELETE
+```
+
+## Other
+
+Demo-only API endpoints that don't have a real counterpart. We use them to fail or stall requests on purpose as well as to demo and test elements that implement a universal authentication protocol (e.g. `foxy-sign-in-form`):
+
+```text
+https://demo.foxycart.com/s/customer/not-found GET
+https://demo.foxycart.com/s/customer/sleep GET
+
+https://demo.foxycart.com/s/virtual/recovery GET, POST, PATCH, DELETE
+https://demo.foxycart.com/s/virtual/session GET, POST, DELETE
+
+https://demo.foxycart.com/s/admin/not-found GET
+https://demo.foxycart.com/s/admin/sleep GET
+```
+
+If you need to add a new endpoint for a hAPI resource, ask @pheekus for help or try to replicate the approach in `src/server`. A few pointers to get you started: we use [Dexie](https://dexie.org) to query IndexedDB in [DemoDatabase.ts](../src/server/DemoDatabase.ts), the dataset is in [dump.json](../src/server/dump.json), and the routing is handled with [service-worker-router](https://github.com/berstend/service-worker-router).
+
+## Using Mock Server in Tests
+
+To use mock server in your tests, route all requests through it like in the example below:
+
+```ts
+import './index';
+
+import { html, expect, fixture, waitUntil } from '@open-wc/testing';
+import { getTestData } from '../../../utils/getTestData';
+import { router } from '../../../server';
+import { CustomFieldForm } from './CustomFieldForm';
+
+it('loads data from the URL', async () => {
+  const url = 'https://demo.foxycart.test/s/admin/custom_fields/0';
+  const serve = (evt: FetchEvent) => router.handleEvent(evt);
+  const layout = html`<foxy-custom-field-form @fetch=${serve}></foxy-custom-field-form>`;
+  const element = await fixture<CustomFieldForm>(layout);
+
+  element.href = url;
+  await waitUntil(() => !!element.data);
+
+  expect(element.data).to.deep.equal(await getTestData(url));
+});
+```


### PR DESCRIPTION
This PR adds `CONTRIBUTING.md` along with a few useful pages giving both outside contributors and team members a tour around the growing Elements codebase.