### PR TITLE
fix(foxy-customer-portal): fix hidden controls selector resolution

### DIFF
--- a/src/elements/public/CustomerPortal/InternalCustomerPortalLoggedInView.test.ts
+++ b/src/elements/public/CustomerPortal/InternalCustomerPortalLoggedInView.test.ts
@@ -41,12 +41,11 @@ describe('InternalCustomerPortalLoggedInViewTest', () => {
 
     const customer = (await getByTestId(element, 'customer')) as Customer;
     const hiddenByDefault = [
-      'header:actions:edit:form:delete',
       'attributes',
       'transactions',
       'subscriptions',
       'addresses:actions:create',
-      'payment-methods:list:card',
+      'header:actions:edit:form:delete',
     ];
 
     expect(customer).to.be.instanceOf(Customer);


### PR DESCRIPTION
Since `foxy-customer-portal` is built on top of `foxy-customer` with custom templates, we have to transform the hidden controls selector before passing it down to underlying elements. This way we can ensure that, for example, the original Subscriptions section is always hidden and a custom one is shown instead. As it turns out, there's been a flaw in the selector resolution algorithm, and with some values the original sections were rendered anyway. This PR fixes that issue.