### PR TITLE
fix: turn off escaping for interpolation results

### DIFF
--- a/src/elements/public/I18n/I18n.ts
+++ b/src/elements/public/I18n/I18n.ts
@@ -119,7 +119,7 @@ export class I18n extends TranslatableMixin(LitElement, '') {
 }
 
 I18n.i18next.init({
-  interpolation: { format },
+  interpolation: { format, escapeValue: false },
   fallbackLng: 'en',
   fallbackNS: 'shared',
   defaultNS: 'shared',


### PR DESCRIPTION
@rijarobinson has noticed that item names had `&amp;` in them where `&` should have been instead. Turns out all interpolated values in our i18n system were automatically escaped, which is absolutely unnecessary for lit-html templates. This PR disables escaping by default.