### PR TITLE
feat(customer-portal): Add Swedish translation

### DIFF
--- a/src/elements/public/CustomerPortal/CustomerPortal.stories.ts
+++ b/src/elements/public/CustomerPortal/CustomerPortal.stories.ts
@@ -82,7 +82,7 @@ const summary: Summary = {
 };
 
 const Meta = getMeta(summary);
-(Meta.argTypes as any).lang.control.options = ['en', 'es', 'de', 'pl', 'zh-HK'];
+(Meta.argTypes as any).lang.control.options = ['en', 'es', 'de', 'pl', 'zh-HK', 'se'];
 export default Meta;
 
 export const Playground = getStory({ ...summary, code: true });

--- a/src/mixins/translatable.ts
+++ b/src/mixins/translatable.ts
@@ -132,7 +132,7 @@ export abstract class Translatable extends Themeable {
 
     this.__whenI18NReady = this.__i18n.init({
       ns: ['global'],
-      supportedLngs: ['nl', 'en', 'es', 'sv', 'fi', 'fr', 'de', 'zh', 'no', 'it', 'pl'],
+      supportedLngs: ['nl', 'en', 'es', 'sv', 'fi', 'fr', 'de', 'zh', 'no', 'it', 'pl', 'se'],
       interpolation: { format: Translatable.__f },
       fallbackLng: 'en',
       fallbackNS: 'global',

--- a/src/static/translations/customer-portal/se.json
+++ b/src/static/translations/customer-portal/se.json
@@ -1,0 +1,223 @@
+{
+  "access-recovery-form": {
+    "back": "Tillbaka",
+    "email": "Email",
+    "recover_access": "Få engångskod",
+    "recover_access_hint": "Ange din e-postadress så skickar vi ett tillfälligt lösenord till dig",
+    "recover_access_success": "Klart! Kontrollera din e-post för ytterligare instruktioner.",
+    "unknown_error": "Vi kan inte utfärda en engångskod för det här kontot för tillfället. Om du redan har begärt koden, vänta några minuter innan du försöker igen.",
+    "v8n_invalid_email": "Ogiltig e-postadress",
+    "v8n_required": "Nödvändig",
+    "spinner": {
+      "loading_busy": "Laddar",
+      "loading_error": "Kan inte ladda"
+    }
+  },
+  "customer": {
+    "address_plural": "Adresser",
+    "cancel": "Avbryt",
+    "close": "Stäng",
+    "payment_method_plural": "Betalningsmetoder",
+    "save": "Save",
+    "subscription_plural": "Prenumerationer",
+    "transaction_plural": "Transaktioner",
+    "undo_cancel": "Recension",
+    "undo_confirm": "Kassera",
+    "undo_header": "Ändringar är ej sparade",
+    "undo_message": "Det verkar som att du inte har sparat dina ändringar! Vad skulle du vilja göra med dem?",
+    "update": "Uppdatera",
+    "address-card": {
+      "default_billing_address": "Standardfaktureringsadress",
+      "default_shipping_address": "Standard leveransadress",
+      "full_address": "{{address1}} {{address2}} {{city}} {{region}} {{postal_code}}",
+      "full_name": "{{first_name}} {{last_name}}",
+      "spinner": {
+        "loading_busy": "laddar",
+        "loading_empty": "Ingen adress",
+        "loading_end": "Ingen mer data",
+        "loading_error": "Lyckades inte ladda"
+      }
+    },
+    "address-form": {
+      "address_name": "Adress namn",
+      "address1": "Adress 1",
+      "address2": "Adress 2",
+      "cancel": "Avbryt",
+      "city": "Stad",
+      "company": "Företag",
+      "country": "Land",
+      "date": "{{value, date}}",
+      "date_created": "Skapades",
+      "date_modified": "Senast uppdaterad",
+      "delete": "Radera",
+      "delete_prompt": "Den här resursen kommer att tas bort permanent. Är du säker?",
+      "first_name": "Förnamn",
+      "last_name": "Efternamn",
+      "phone": "Telefon",
+      "postal_code": "Postkod",
+      "region": "Region",
+      "v8n_required": "Nödvändig",
+      "v8n_too_long": "För lång",
+      "spinner": {
+        "loading_busy": "Laddar",
+        "loading_empty": "Ingen data",
+        "loading_error": "Lyckades inte ladda"
+      }
+    },
+    "customer-form": {
+      "cancel": "Avbryt",
+      "change_password": "Byt lösenord",
+      "change_password_step_1": "Låt oss börja med ditt nuvarande lösenord. Ett tillfälligt lösenord fungerar också om du har ett.",
+      "change_password_step_2": "Ange nu ett nytt lösenord och tryck på Fortsätt för att tillämpa ändringar på ditt konto.",
+      "change_password_step_3": "Klart! Du kan nu använda ditt nya lösenord när du loggar in.",
+      "close": "Stäng",
+      "date": "{{value, date}}",
+      "date_created": "Skapades",
+      "date_modified": "Senast uppdaterad",
+      "email": "Email",
+      "first_name": "Förnamn",
+      "invalid_credential_error": "Fel lösenord. Se till att du har angett ditt nuvarande eller tillfälliga lösenord och försök igen.",
+      "last_name": "Efternamn",
+      "sign_in": "Fortsätt",
+      "tax_id": "Moms ID",
+      "undo_cancel": "Säkerställ info",
+      "undo_confirm": "Radera",
+      "undo_header": "Ändringar ej sparade",
+      "undo_message": "Det verkar som att du inte har sparat dina ändringar! Vad skulle du vilja göra med dem?",
+      "v8n_invalid_email": "Ogilig e-post",
+      "v8n_required": "Nödvänding",
+      "v8n_too_long": "För lång",
+      "sign-in-form": {
+        "new_password": "Nytt lösenord",
+        "password": "Lösenord",
+        "spinner": {
+          "loading_busy": "Laddar",
+          "loading_error": "Lyckades inte ladda"
+        }
+      },
+      "spinner": {
+        "loading_busy": "laddar",
+        "loading_empty": "No data",
+        "loading_error": "Lyckades inte ladda"
+      }
+    },
+    "payment-method-card": {
+      "cancel": "Avbryt",
+      "delete": "Radera",
+      "delete_prompt": "Den här resursen kommer att tas bort permanent. Är du säker?",
+      "spinner": {
+        "loading_busy": "Laddar",
+        "loading_empty": "Inga betalningsmetoder",
+        "loading_error": "Lyckades inte ladda"
+      }
+    },
+    "spinner": {
+      "loading_busy": "Laddar",
+      "loading_error": "Lyckades inte ladda"
+    },
+    "subscription-card": {
+      "daily": "Daglig",
+      "daily_plural": "Alla {{count}} dagar",
+      "frequency": "$t(customer.subscription-card.{{units}}, { \"count\": {{count}}, \"ns\": \"customer-portal\" })",
+      "monthly": "Månadsvis",
+      "monthly_plural": "Alla {{count}} månader",
+      "price_recurring": "{{amount, price}} $t(customer.subscription-card.frequency, { \"count\": \"{{count}}\", \"units\": \"{{units}}\", \"ns\": \"customer-portal\" })",
+      "price_twice_a_month": "{{amount, price}} $t(customer.subscription-card.twice_a_month, { \"ns\": \"customer-portal\" })",
+      "subscription_active": "Nästa betalning på {{date, date}}",
+      "subscription_cancelled": "Slutade på {{date, date}}",
+      "subscription_failed": "Betalningen misslyckades den {{date, date}}",
+      "subscription_inactive": "Inaktiv",
+      "subscription_will_be_cancelled": "Slutar den {{date, date}}",
+      "transaction_summary": "{{most_expensive_item.name}}",
+      "twice_a_month": "Varannan vecka",
+      "weekly": "Veckovis",
+      "weekly_plural": "Alla {{count}} vecka",
+      "yearly": "Årlig",
+      "yearly_plural": "Alla {{count}} years",
+      "spinner": {
+        "loading_busy": "Laddar",
+        "loading_empty": "Inga prenumerationer",
+        "loading_end": "Ingen mer data",
+        "loading_error": "Lyckades inte ladda"
+      }
+    },
+    "subscription-form": {
+      "daily": "Daglig",
+      "daily_plural": "Alla {{count}} dagar",
+      "end_subscription": "Avsluta prenumerationen",
+      "frequency": "$t(customer.subscription-form.{{units}}, { \"count\": {{count}}, \"ns\": \"customer-portal\" })",
+      "frequency_label": "Frekvens",
+      "item_plural": "Artiklar",
+      "monthly": "Månadsvis",
+      "monthly_plural": "Alla {{count}} månader",
+      "next_transaction_date": "Nästa transaktionsdatum",
+      "price_recurring": "{{amount, price}} $t(customer.subscription-form.frequency, { \"count\": \"{{count}}\", \"units\": \"{{units}}\", \"ns\": \"customer-portal\" })",
+      "price_twice_a_month": "{{amount, price}} $t(customer.subscription-form.twice_a_month, { \"ns\": \"customer-portal\" })",
+      "subscription_active": "Nästa betalning på {{date, date}}",
+      "subscription_cancelled": "Slutade på {{date, date}}",
+      "subscription_failed": "Betalningen misslyckades den {{date, date}}",
+      "subscription_inactive": "Inaktiv",
+      "subscription_will_be_cancelled": "Slutar på {{date, date}}",
+      "transaction_plural": "Transaktioner",
+      "twice_a_month": "Varannan vecka",
+      "update_billing": "Uppdatera fakturering",
+      "update_items": "Redigera",
+      "weekly": "Veckovis",
+      "weekly_plural": "Alla {{count}} veckor",
+      "yearly": "Årlig",
+      "yearly_plural": "Alla {{count}} år",
+      "spinner": {
+        "loading_busy": "Laddar",
+        "loading_error": "Lyckades inte ladda"
+      },
+      "transactions-table": {
+        "date": "{{value, date}}",
+        "price": "{{amount, price}}",
+        "receipt": "Kvitto",
+        "spinner": {
+          "loading_busy": "Laddar",
+          "loading_empty": "Inga transaktioner",
+          "loading_error": "Lyckades inte ladda"
+        }
+      }
+    },
+    "transactions-table": {
+      "date": "{{value, date}}",
+      "price": "{{amount, price}}",
+      "receipt": "Kvitto",
+      "transaction_approved": "Godkänd",
+      "transaction_authorized": "Auktoriserad",
+      "transaction_captured": "Inkommen",
+      "transaction_completed": "Avslutad",
+      "transaction_declined": "Avböjd",
+      "transaction_pending": "I väntan på",
+      "transaction_refunded": "Återbetalad",
+      "transaction_rejected": "Avvisad",
+      "transaction_summary": "{{most_expensive_item.name}}",
+      "transaction_summary_plural": "{{most_expensive_item.name}} and {{count}} more",
+      "transaction_verified": "Verifierad",
+      "transaction_voided": "Ogiltigförklarad",
+      "spinner": {
+        "loading_busy": "Laddar",
+        "loading_empty": "Inga transaktioner",
+        "loading_end": "Inga mer data",
+        "loading_error": "Lyckades inte ladda"
+      }
+    }
+  },
+  "sign-in-form": {
+    "email": "E-post",
+    "invalid_credential_error": "Felaktig e-postadress eller lösenord. Kontrollera dina uppgifter och försök igen.",
+    "password": "Lösenord",
+    "recover_access": "Få engångskod",
+    "sign_in": "Logga in",
+    "sign_in_hint": "Vänligen ange din e-postadress och ditt lösenord",
+    "unknown_error": "Ett okänt fel har inträffat. Vänligen försök igen senare.",
+    "v8n_invalid_email": "Ogiltig e-postadress",
+    "v8n_required": "Nödvänding",
+    "spinner": {
+      "loading_busy": "Laddar",
+      "loading_error": "Lyckades inte ladda"
+    }
+  }
+}


### PR DESCRIPTION
Introducing Swedish language strings for the customer portal, sourced from a translation provided by a member of our community.

Addresses #94 