### PR TITLE
fix(foxy-customer-portal): fix Change Password dialog translations

### DIFF
--- a/src/static/schemas/customer-portal.json
+++ b/src/static/schemas/customer-portal.json
@@ -254,18 +254,18 @@
             "last_name": {
               "$ref": "customer-form.json#/properties/last_name"
             },
+            "new_password": {
+              "$ref": "sign-in-form.json#/properties/new_password"
+            },
+            "password": {
+              "$ref": "sign-in-form.json#/properties/password"
+            },
             "sign_in": {
               "default": "Continue",
               "type": "string"
             },
             "sign-in-form": {
               "properties": {
-                "new_password": {
-                  "$ref": "sign-in-form.json#/properties/new_password"
-                },
-                "password": {
-                  "$ref": "sign-in-form.json#/properties/password"
-                },
                 "spinner": {
                   "properties": {
                     "loading_busy": {
@@ -279,7 +279,7 @@
                   "additionalProperties": false
                 }
               },
-              "required": ["new_password", "password", "spinner"],
+              "required": ["spinner"],
               "additionalProperties": false
             },
             "spinner": {
@@ -340,6 +340,8 @@
             "first_name",
             "invalid_credential_error",
             "last_name",
+            "new_password",
+            "password",
             "sign_in",
             "tax_id",
             "undo_cancel",
@@ -389,6 +391,9 @@
         },
         "save": {
           "$ref": "customer.json#/properties/save"
+        },
+        "spinner": {
+          "$ref": "customer.json#/properties/spinner"
         },
         "subscription_plural": {
           "$ref": "customer.json#/properties/subscription_plural"
@@ -743,9 +748,6 @@
         },
         "update": {
           "$ref": "customer.json#/properties/update"
-        },
-        "spinner": {
-          "$ref": "customer.json#/properties/spinner"
         }
       },
       "required": [

--- a/src/static/translations/customer-portal/de.json
+++ b/src/static/translations/customer-portal/de.json
@@ -78,6 +78,8 @@
       "first_name": "Vorname",
       "invalid_credential_error": "Falsches Passwort. Bitte vergewissern Sie sich, dass Sie Ihr aktuelles oder temporäres Passwort eingegeben haben und versuchen Sie es erneut.",
       "last_name": "Nachname",
+      "new_password": "Neues Passwort",
+      "password": "Passwort",
       "sign_in": "Weiter",
       "tax_id": "Steuer-ID",
       "undo_cancel": "Überprüfung",
@@ -88,8 +90,6 @@
       "v8n_required": "Erforderlich",
       "v8n_too_long": "Zu lang",
       "sign-in-form": {
-        "new_password": "Neues Passwort",
-        "password": "Passwort",
         "spinner": {
           "loading_busy": "Wird geladen",
           "loading_error": "Wurde nicht geladen"

--- a/src/static/translations/customer-portal/en.json
+++ b/src/static/translations/customer-portal/en.json
@@ -78,6 +78,8 @@
       "first_name": "First name",
       "invalid_credential_error": "Incorrect password. Please make sure you've entered your current or temporary password and try again.",
       "last_name": "Last name",
+      "new_password": "New password",
+      "password": "Password",
       "sign_in": "Continue",
       "tax_id": "Tax ID",
       "undo_cancel": "Review",
@@ -88,8 +90,6 @@
       "v8n_required": "Required",
       "v8n_too_long": "Too long",
       "sign-in-form": {
-        "new_password": "New password",
-        "password": "Password",
         "spinner": {
           "loading_busy": "Loading",
           "loading_error": "Failed to load"

--- a/src/static/translations/customer-portal/es.json
+++ b/src/static/translations/customer-portal/es.json
@@ -78,6 +78,8 @@
       "first_name": "Vorname",
       "invalid_credential_error": "Contraseña incorrecta. Asegúrese de haber ingresado su contraseña actual o temporal y vuelva a intentarlo.",
       "last_name": "Nachname",
+      "new_password": "Nueva contraseña",
+      "password": "Contraseña",
       "sign_in": "Continuar",
       "tax_id": "Número de identificación fiscal",
       "undo_cancel": "Revisar",
@@ -88,8 +90,6 @@
       "v8n_required": "Obligatorio",
       "v8n_too_long": "Demasiado largo",
       "sign-in-form": {
-        "new_password": "Nueva contraseña",
-        "password": "Contraseña",
         "spinner": {
           "loading_busy": "Cargando",
           "loading_error": "No se pudo cargar"

--- a/src/static/translations/customer-portal/pl.json
+++ b/src/static/translations/customer-portal/pl.json
@@ -78,6 +78,8 @@
       "first_name": "Imię",
       "invalid_credential_error": "Niepoprawne hasło. Upewnij się, że wpisałeś swoje obecne lub tymczasowe hasło i spróbuj ponownie.",
       "last_name": "Nazwisko",
+      "new_password": "Nowe hasło",
+      "password": "Hasło",
       "sign_in": "Kontynuuj",
       "tax_id": "NIP",
       "undo_cancel": "Przegląd",
@@ -88,8 +90,6 @@
       "v8n_required": "Wymagany",
       "v8n_too_long": "Za długo",
       "sign-in-form": {
-        "new_password": "Nowe hasło",
-        "password": "Hasło",
         "spinner": {
           "loading_busy": "Ładowanie",
           "loading_error": "Nie udało się załadować"

--- a/src/static/translations/customer-portal/se.json
+++ b/src/static/translations/customer-portal/se.json
@@ -78,6 +78,8 @@
       "first_name": "Förnamn",
       "invalid_credential_error": "Fel lösenord. Se till att du har angett ditt nuvarande eller tillfälliga lösenord och försök igen.",
       "last_name": "Efternamn",
+      "new_password": "Nytt lösenord",
+      "password": "Lösenord",
       "sign_in": "Fortsätt",
       "tax_id": "Moms ID",
       "undo_cancel": "Säkerställ info",
@@ -88,8 +90,6 @@
       "v8n_required": "Nödvänding",
       "v8n_too_long": "För lång",
       "sign-in-form": {
-        "new_password": "Nytt lösenord",
-        "password": "Lösenord",
         "spinner": {
           "loading_busy": "Laddar",
           "loading_error": "Lyckades inte ladda"

--- a/src/static/translations/customer-portal/zh-hk.json
+++ b/src/static/translations/customer-portal/zh-hk.json
@@ -78,6 +78,8 @@
       "first_name": "名",
       "invalid_credential_error": "密碼錯誤。 請確保您已輸入現時或臨時密碼，然後重試。",
       "last_name": "姓",
+      "new_password": "新密碼",
+      "password": "密碼",
       "sign_in": "繼續",
       "tax_id": "稅務編號",
       "undo_cancel": "審核",
@@ -88,8 +90,6 @@
       "v8n_required": "必需的",
       "v8n_too_long": "太長",
       "sign-in-form": {
-        "new_password": "新密碼",
-        "password": "密碼",
         "spinner": {
           "loading_busy": "載入中",
           "loading_error": "加載失敗"


### PR DESCRIPTION
This PR puts built-in translations for `password` and `new_password` keys in the Change Password dialog into the right place.