### PR TITLE
fix(foxy-customer-portal): fix `hiddencontrols` selector for logged in view

### DIFF
--- a/src/elements/public/CustomerPortal/InternalCustomerPortalLoggedInView.ts
+++ b/src/elements/public/CustomerPortal/InternalCustomerPortalLoggedInView.ts
@@ -146,14 +146,16 @@ export class InternalCustomerPortalLoggedInView extends Base<Data> {
 
   render(): TemplateResult {
     const hiddenSelector = this.hiddenSelector.zoom('customer');
-    const customerHiddenControls = new BooleanSelector(`
-      attributes
-      transactions
-      subscriptions
-      addresses:actions:create
-      header:actions:edit:form:delete
-      ${hiddenSelector.toString()}
-    `).toString();
+    const customerHiddenControls = new BooleanSelector(
+      [
+        'attributes',
+        'transactions',
+        'subscriptions',
+        'addresses:actions:create',
+        'header:actions:edit:form:delete',
+        hiddenSelector.toString(),
+      ].join(' ')
+    ).toString();
 
     const templates: CustomerTemplates = this.getNestedTemplates('customer');
     const originalHeaderActionsAfterTemplate = templates['header:actions:after'];


### PR DESCRIPTION
BooleanSelector is sensitive to newline characters. In some instances, it was preventing devs from applying complex customizations that involved hiding controls deep in the Shadow DOM. This commit addresses that issue.