### PR TITLE
fix: revert to old post handling in virtual api forms

### DIFF
--- a/src/elements/public/AccessRecoveryForm/AccessRecoveryForm.ts
+++ b/src/elements/public/AccessRecoveryForm/AccessRecoveryForm.ts
@@ -167,4 +167,15 @@ export class AccessRecoveryForm extends Base<Data> {
       </main>
     `;
   }
+
+  protected async _sendPost(edits: Partial<Data>): Promise<Data> {
+    const body = JSON.stringify(edits);
+    const data = await this._fetch(this.parent, { body, method: 'POST' });
+
+    const rumour = NucleonElement.Rumour(this.group);
+    const related = [...this.related, this.parent];
+    rumour.share({ data, related, source: data._links.self.href });
+
+    return data;
+  }
 }

--- a/src/elements/public/SignInForm/SignInForm.ts
+++ b/src/elements/public/SignInForm/SignInForm.ts
@@ -407,6 +407,17 @@ export class SignInForm extends Base<Data> {
     `;
   }
 
+  protected async _sendPost(edits: Partial<Data>): Promise<Data> {
+    const body = JSON.stringify(edits);
+    const data = await this._fetch(this.parent, { body, method: 'POST' });
+
+    const rumour = NucleonElement.Rumour(this.group);
+    const related = [...this.related, this.parent];
+    rumour.share({ data, related, source: data._links.self.href });
+
+    return data;
+  }
+
   protected async _fetch<TResult = Data>(...args: Parameters<Window['fetch']>): Promise<TResult> {
     try {
       return await super._fetch(...args);


### PR DESCRIPTION
Normal resource creation logic sends a GET request upon receiving 200 OK from POST. In the special forms like sign in and access recovery forms that effectively skips the confirmation screen. Reverting to the old approach with this PR.