### PR TITLE
chore: release 1.22.1

### DIFF
--- a/src/elements/internal/InternalAsyncListControl/InternalAsyncListControl.test.ts
+++ b/src/elements/internal/InternalAsyncListControl/InternalAsyncListControl.test.ts
@@ -73,6 +73,22 @@ describe('InternalAsyncListControl', () => {
     expect(new Control()).to.be.instanceOf(InternalEditableControl);
   });
 
+  it('has a reactive property "keepDialogOpenOnDelete"', () => {
+    expect(new Control()).to.have.property('keepDialogOpenOnDelete', false);
+    expect(Control).to.have.deep.nested.property('properties.keepDialogOpenOnDelete', {
+      type: Boolean,
+      attribute: 'keep-dialog-open-on-delete',
+    });
+  });
+
+  it('has a reactive property "keepDialogOpenOnPost"', () => {
+    expect(new Control()).to.have.property('keepDialogOpenOnPost', false);
+    expect(Control).to.have.deep.nested.property('properties.keepDialogOpenOnPost', {
+      type: Boolean,
+      attribute: 'keep-dialog-open-on-post',
+    });
+  });
+
   it('has a reactive property "hideDeleteButton"', () => {
     expect(new Control()).to.have.property('hideDeleteButton', false);
     expect(Control).to.have.deep.nested.property('properties.hideDeleteButton', {
@@ -150,10 +166,14 @@ describe('InternalAsyncListControl', () => {
     expect(form).to.have.attribute('infer', 'dialog');
     expect(form).to.have.property('form', 'foxy-attribute-form');
     expect(form).to.have.deep.property('related', []);
+    expect(form).to.not.have.attribute('keep-open-on-delete');
+    expect(form).to.not.have.attribute('keep-open-on-post');
     expect(form).to.not.have.attribute('parent');
     expect(form).to.not.have.attribute('alert');
     expect(form).to.not.have.attribute('wide');
 
+    control.keepDialogOpenOnDelete = true;
+    control.keepDialogOpenOnPost = true;
     control.related = ['https://demo.api/virtual/error'];
     control.first = 'https://demo.api/virtual/stall';
     control.alert = true;
@@ -162,6 +182,8 @@ describe('InternalAsyncListControl', () => {
     await control.updateComplete;
 
     expect(form).to.have.deep.property('related', ['https://demo.api/virtual/error']);
+    expect(form).to.have.attribute('keep-open-on-delete');
+    expect(form).to.have.attribute('keep-open-on-post');
     expect(form).to.have.attribute('parent', 'https://demo.api/virtual/stall');
     expect(form).to.have.attribute('alert');
     expect(form).to.have.attribute('wide');

--- a/src/elements/internal/InternalAsyncListControl/InternalAsyncListControl.ts
+++ b/src/elements/internal/InternalAsyncListControl/InternalAsyncListControl.ts
@@ -14,6 +14,8 @@ export class InternalAsyncListControl extends InternalEditableControl {
   static get properties(): PropertyDeclarations {
     return {
       ...super.properties,
+      keepDialogOpenOnDelete: { type: Boolean, attribute: 'keep-dialog-open-on-delete' },
+      keepDialogOpenOnPost: { type: Boolean, attribute: 'keep-dialog-open-on-post' },
       hideDeleteButton: { type: Boolean, attribute: 'hide-delete-button' },
       hideCreateButton: { type: Boolean, attribute: 'hide-create-button' },
       createPageHref: { attribute: 'create-page-href' },
@@ -27,6 +29,12 @@ export class InternalAsyncListControl extends InternalEditableControl {
       alert: { type: Boolean },
     };
   }
+
+  /** If true, FormDialog won't automatically close after the associated form deletes the resource. */
+  keepDialogOpenOnDelete = false;
+
+  /** If true, FormDialog won't automatically close after the associated form creates a resource. */
+  keepDialogOpenOnPost = false;
 
   /** If provided, renders Create button as a link to this page. */
   createPageHref: string | null = null;
@@ -159,6 +167,8 @@ export class InternalAsyncListControl extends InternalEditableControl {
               id="form"
               ?wide=${this.wide}
               ?alert=${this.alert}
+              ?keep-open-on-post=${this.keepDialogOpenOnPost}
+              ?keep-open-on-delete=${this.keepDialogOpenOnDelete}
               .related=${this.related}
               .form=${this.form as any}
             >

--- a/src/elements/public/CustomerPortal/InternalCustomerPortalChangePassword.ts
+++ b/src/elements/public/CustomerPortal/InternalCustomerPortalChangePassword.ts
@@ -114,7 +114,7 @@ export class InternalCustomerPortalChangePassword extends Base {
         readonlycontrols=${readonlyControls.join(' ')}
         hiddencontrols=${hiddenControls.join(' ')}
         parent=${this.session}
-        class="mt-s sm-w-narrow-modal"
+        class="mt-s"
         lang=${ctx.dialog.lang}
         ns=${ctx.dialog.ns}
         @update=${(evt: UpdateEvent) => this.__handleSignInFormUpdate(evt, ctx)}

--- a/src/elements/public/CustomerPortal/InternalCustomerPortalChangePassword.ts
+++ b/src/elements/public/CustomerPortal/InternalCustomerPortalChangePassword.ts
@@ -145,6 +145,7 @@ export class InternalCustomerPortalChangePassword extends Base {
         ns=${this.ns}
         alert
         id="dialog"
+        keep-open-on-post
         .form=${this.__renderSignInForm}
       >
       </foxy-form-dialog>

--- a/src/elements/public/ItemForm/ItemForm.ts
+++ b/src/elements/public/ItemForm/ItemForm.ts
@@ -93,6 +93,22 @@ export class ItemForm extends TranslatableMixin(InternalForm, 'item-form')<Data>
       </div>
 
       <foxy-internal-item-form-subscription-control></foxy-internal-item-form-subscription-control>
+
+      ${this.data
+        ? html`
+            <foxy-internal-async-details-control
+              infer="item-options"
+              first=${this.data._links['fx:item_options'].href}
+              limit="5"
+              form="foxy-item-option-form"
+              item="foxy-item-option-card"
+              .related=${this.__itemOptionRelatedUrls}
+              .props=${{ 'locale-codes': this.localeCodes ?? '' }}
+            >
+            </foxy-internal-async-details-control>
+          `
+        : ''}
+
       <foxy-internal-item-form-line-item-discount-control></foxy-internal-item-form-line-item-discount-control>
       <foxy-internal-item-form-cart-control></foxy-internal-item-form-cart-control>
       <foxy-internal-item-form-shipping-control></foxy-internal-item-form-shipping-control>
@@ -122,17 +138,6 @@ export class ItemForm extends TranslatableMixin(InternalForm, 'item-form')<Data>
               limit="5"
               item="foxy-attribute-card"
               form="foxy-attribute-form"
-            >
-            </foxy-internal-async-details-control>
-
-            <foxy-internal-async-details-control
-              infer="item-options"
-              first=${this.data._links['fx:item_options'].href}
-              limit="5"
-              form="foxy-item-option-form"
-              item="foxy-item-option-card"
-              .related=${this.__itemOptionRelatedUrls}
-              .props=${{ 'locale-codes': this.localeCodes ?? '' }}
             >
             </foxy-internal-async-details-control>
           `


### PR DESCRIPTION
### Bug Fixes

* **foxy-customer-portal:** fix change password layout on sm+ viewports ([5aace5a](https://github.com/Foxy/foxy-elements/commit/5aace5abd8fc8a502566a41c22025da6cc91641d))
* **foxy-customer-portal:** keep change password dialog open on success ([0b6016c](https://github.com/Foxy/foxy-elements/commit/0b6016c73c3142ea7af3657cc880711de096ccbd))