### PR TITLE
docs: update generic help link

### DIFF
--- a/src/static/translations/global/en.json
+++ b/src/static/translations/global/en.json
@@ -62,7 +62,7 @@
       "title": "Setup needed",
       "message": "This element isn't configured to display any data yet. Please consult our docs for setup instructions.",
       "action": "See docs",
-      "href": "https://docs.foxy.io"
+      "href": "https://foxy.io/help"
     }
   }
 }


### PR DESCRIPTION
docs.foxy.io doesn't go anywhere so this at least fixes a broken link.