### PR TITLE
chore: release 1.49.0

### DIFF
--- a/src/elements/internal/InternalAsyncListControl/InternalAsyncListControl.test.ts
+++ b/src/elements/internal/InternalAsyncListControl/InternalAsyncListControl.test.ts
@@ -245,6 +245,14 @@ describe('InternalAsyncListControl', () => {
     expect(Control).to.have.deep.nested.property('properties.filter', {});
   });
 
+  it('has a reactive property "extendFilter"', () => {
+    expect(new Control()).to.have.property('extendFilter', null);
+    expect(Control).to.have.deep.nested.property('properties.extendFilter', {
+      type: Function,
+      attribute: false,
+    });
+  });
+
   it('renders a form dialog if "form" is specified', async () => {
     const control = await fixture<Control>(html`
       <foxy-internal-async-list-control></foxy-internal-async-list-control>
@@ -432,8 +440,14 @@ describe('InternalAsyncListControl', () => {
       control.first = 'https://demo.api/virtual/stall';
       control.limit = 5;
       await control.requestUpdate();
-
       expect(pagination).to.have.attribute('first', 'https://demo.api/virtual/stall?limit=5');
+
+      control.extendFilter = (params: URLSearchParams) => params.set('foo', 'bar');
+      await control.requestUpdate();
+      expect(pagination).to.have.attribute(
+        'first',
+        'https://demo.api/virtual/stall?limit=5&foo=bar'
+      );
     });
 
     it(`renders a collection page under pagination in ${layoutLabel} layout`, async () => {

--- a/src/elements/internal/InternalAsyncListControl/InternalAsyncListControl.ts
+++ b/src/elements/internal/InternalAsyncListControl/InternalAsyncListControl.ts
@@ -43,6 +43,7 @@ export class InternalAsyncListControl extends InternalEditableControl {
       bulkActions: { attribute: false },
       filters: { type: Array },
       filter: {},
+      extendFilter: { type: Function, attribute: false },
       __selection: { attribute: false },
       __totalItems: { attribute: false },
       __isSelecting: { attribute: false },
@@ -115,7 +116,11 @@ export class InternalAsyncListControl extends InternalEditableControl {
   /** If set, renders list items as <a> tags. */
   getPageHref: ((itemHref: string, item: unknown) => string | null) | null = null;
 
+  /** Filter applied to the dataset query. */
   filter: string | null = null;
+
+  /** Function to extend the filters applied to the dataset query without making it obvious to the user. */
+  extendFilter: ((params: URLSearchParams) => void) | null = null;
 
   private __deletionConfimationCallback: (() => void) | null = null;
 
@@ -581,6 +586,7 @@ export class InternalAsyncListControl extends InternalEditableControl {
 
       url.searchParams.set('limit', String(this.limit));
       filter.forEach((value, key) => url.searchParams.set(key, value));
+      this.extendFilter?.(url.searchParams);
       first = url.toString();
     } catch {
       first = undefined;

--- a/src/elements/internal/InternalPasswordControl/InternalPasswordControl.test.ts
+++ b/src/elements/internal/InternalPasswordControl/InternalPasswordControl.test.ts
@@ -76,6 +76,13 @@ describe('InternalTextControl', () => {
     expect(new Control()).to.have.property('showGenerator', false);
   });
 
+  it('has a reactive property "visibilityToggle"', () => {
+    expect(new Control()).to.have.property('visibilityToggle', null);
+    expect(Control).to.have.deep.nested.property('properties.visibilityToggle', {
+      attribute: 'visibility-toggle',
+    });
+  });
+
   it('has a reactive property "layout"', () => {
     expect(Control).to.have.deep.nested.property('properties.layout', {});
     expect(new Control()).to.have.property('layout', null);
@@ -277,5 +284,31 @@ describe('InternalTextControl', () => {
 
     button.click();
     expect(control.testValue).to.equal('abc');
+  });
+
+  it('replaces Reveal Password button with Copy Password button when "visibilityToggle" is "copy"', async () => {
+    const control = await fixture<TestControl>(html`
+      <test-internal-password-control visibility-toggle="copy"></test-internal-password-control>
+    `);
+
+    const field = control.renderRoot.querySelector('vaadin-password-field')!;
+    expect(field).to.have.attribute('reveal-button-hidden');
+
+    let button = control.renderRoot.querySelector<HTMLElement>('foxy-copy-to-clipboard')!;
+    expect(button).to.have.attribute('layout', 'icon-inline');
+    expect(button).to.have.attribute('text', control.testValue);
+    expect(button).to.have.attribute('infer', '');
+
+    control.visibilityToggle = 'reveal';
+    await control.requestUpdate();
+    button = control.renderRoot.querySelector<HTMLElement>('foxy-copy-to-clipboard')!;
+    expect(button).to.not.exist;
+    expect(field).to.not.have.attribute('reveal-button-hidden');
+
+    control.visibilityToggle = null;
+    await control.requestUpdate();
+    button = control.renderRoot.querySelector<HTMLElement>('foxy-copy-to-clipboard')!;
+    expect(button).to.not.exist;
+    expect(field).to.not.have.attribute('reveal-button-hidden');
   });
 });

--- a/src/elements/internal/InternalPasswordControl/InternalPasswordControl.ts
+++ b/src/elements/internal/InternalPasswordControl/InternalPasswordControl.ts
@@ -19,12 +19,16 @@ export class InternalPasswordControl extends InternalEditableControl {
     return {
       ...super.properties,
       generatorOptions: { type: Object, attribute: 'generator-options' },
+      visibilityToggle: { attribute: 'visibility-toggle' },
       showGenerator: { type: Boolean, attribute: 'show-generator' },
       layout: {},
     };
   }
 
   generatorOptions: null | GeneratorOptions = null;
+
+  /** Password visibility toggle mode, "reveal" by default which shows Reveal Password button. If set to "copy", shows "Copy Password" button instead. */
+  visibilityToggle: 'reveal' | 'copy' | null = null;
 
   /** If true, renders the password generator button. */
   showGenerator = false;
@@ -40,6 +44,7 @@ export class InternalPasswordControl extends InternalEditableControl {
         label=${this.label}
         theme=${ifDefined(this.layout ?? void 0)}
         class="w-full"
+        ?reveal-button-hidden=${this.visibilityToggle === 'copy'}
         ?disabled=${this.disabled}
         ?readonly=${this.readonly}
         .checkValidity=${this._checkValidity}
@@ -51,6 +56,7 @@ export class InternalPasswordControl extends InternalEditableControl {
         }}
       >
         ${this.showGenerator ? this.__renderGenerator() : ''}
+        ${this.visibilityToggle === 'copy' ? this.__renderCopyButton() : ''}
       </vaadin-password-field>
     `;
   }
@@ -61,6 +67,13 @@ export class InternalPasswordControl extends InternalEditableControl {
 
   protected set _value(newValue: string) {
     super._value = newValue as unknown | undefined;
+  }
+
+  private __renderCopyButton(): TemplateResult {
+    return html`
+      <foxy-copy-to-clipboard layout="icon-inline" infer="" slot="suffix" text=${this._value}>
+      </foxy-copy-to-clipboard>
+    `;
   }
 
   private __renderGenerator(): TemplateResult {

--- a/src/elements/internal/InternalPasswordControl/index.ts
+++ b/src/elements/internal/InternalPasswordControl/index.ts
@@ -1,4 +1,5 @@
 import '@vaadin/vaadin-text-field/vaadin-password-field';
+import '../../public/CopyToClipboard/index';
 import '../InternalEditableControl/index';
 import './vaadinStyles';
 

--- a/src/elements/internal/InternalResourcePickerControl/InternalResourcePickerControl.test.ts
+++ b/src/elements/internal/InternalResourcePickerControl/InternalResourcePickerControl.test.ts
@@ -100,6 +100,14 @@ describe('InternalResourcePickerControl', () => {
     expect(new Control()).to.have.deep.property('filters', []);
   });
 
+  it('has a reactive property "extendFilter"', () => {
+    expect(new Control()).to.have.property('extendFilter', null);
+    expect(Control).to.have.deep.nested.property('properties.extendFilter', {
+      type: Function,
+      attribute: false,
+    });
+  });
+
   it('has a reactive property "layout"', () => {
     expect(Control).to.have.deep.nested.property('properties.layout', {});
     expect(new Control()).to.have.deep.property('layout', null);
@@ -247,6 +255,7 @@ describe('InternalResourcePickerControl', () => {
     expect(dialog).to.have.attribute('alert');
     expect(dialog).to.have.deep.property('props', {
       '.selectionProps': {
+        '.extendFilter': control.extendFilter,
         '.filters': control.filters,
         '.first': control.first,
         '.item': control.item,

--- a/src/elements/internal/InternalResourcePickerControl/InternalResourcePickerControl.ts
+++ b/src/elements/internal/InternalResourcePickerControl/InternalResourcePickerControl.ts
@@ -29,6 +29,7 @@ export class InternalResourcePickerControl extends InternalEditableControl {
       getItemUrl: { attribute: false },
       formProps: { type: Object },
       filters: { type: Array },
+      extendFilter: { type: Function, attribute: false },
       layout: {},
       first: {},
       item: {},
@@ -48,6 +49,9 @@ export class InternalResourcePickerControl extends InternalEditableControl {
   formProps: Record<string, unknown> = {};
 
   filters: Option[] = [];
+
+  /** Function to extend the filters applied to the dataset query without making it obvious to the user. */
+  extendFilter: ((params: URLSearchParams) => void) | null = null;
 
   layout: 'summary-item' | 'standalone' | null = null;
 
@@ -77,7 +81,12 @@ export class InternalResourcePickerControl extends InternalEditableControl {
   renderControl(): TemplateResult {
     const dialogProps = {
       ...this.formProps,
-      '.selectionProps': { '.filters': this.filters, '.first': this.first, '.item': this.item },
+      '.selectionProps': {
+        '.extendFilter': this.extendFilter,
+        '.filters': this.filters,
+        '.first': this.first,
+        '.item': this.item,
+      },
     };
 
     return html`

--- a/src/elements/internal/InternalResourcePickerControl/InternalResourcePickerControl.ts
+++ b/src/elements/internal/InternalResourcePickerControl/InternalResourcePickerControl.ts
@@ -33,6 +33,7 @@ export class InternalResourcePickerControl extends InternalEditableControl {
       first: {},
       item: {},
       form: {},
+      __isErrorVisible: { attribute: false },
     };
   }
 
@@ -55,6 +56,8 @@ export class InternalResourcePickerControl extends InternalEditableControl {
   item: string | null = null;
 
   form: string | null | FormRenderer = null;
+
+  private __isErrorVisible = false;
 
   private readonly __getItemRenderer = memoize((item: string | null) => {
     return new Function(
@@ -86,6 +89,7 @@ export class InternalResourcePickerControl extends InternalEditableControl {
         .props=${dialogProps}
         .form=${this.form ?? 'foxy-internal-resource-picker-control-form'}
         @fetch=${this.__handleFetchEvent}
+        @hide=${() => (this.__isErrorVisible = true)}
       >
       </foxy-form-dialog>
 
@@ -93,6 +97,11 @@ export class InternalResourcePickerControl extends InternalEditableControl {
         ? this.__renderSummaryItemLayout()
         : this.__renderStandaloneLayout()}
     `;
+  }
+
+  reportValidity(): void {
+    this.__isErrorVisible = true;
+    super.reportValidity();
   }
 
   updated(changes: Map<keyof this, unknown>): void {
@@ -169,7 +178,10 @@ export class InternalResourcePickerControl extends InternalEditableControl {
 
         <div style="max-width: 32rem">
           <div class="text-xs text-secondary">${this.helperText}</div>
-          <div class="text-xs text-error" ?hidden=${this.disabled || this.readonly}>
+          <div
+            class="text-xs text-error"
+            ?hidden=${this.disabled || this.readonly || !this.__isErrorVisible}
+          >
             ${this._errorMessage}
           </div>
         </div>

--- a/src/elements/public/CopyToClipboard/CopyToClipboard.ts
+++ b/src/elements/public/CopyToClipboard/CopyToClipboard.ts
@@ -5,6 +5,7 @@ import { TranslatableMixin } from '../../../mixins/translatable';
 import { ConfigurableMixin } from '../../../mixins/configurable';
 import { InferrableMixin } from '../../../mixins/inferrable';
 import { ifDefined } from 'lit-html/directives/if-defined';
+import { classMap } from '../../../utils/class-map';
 
 const NS = 'copy-to-clipboard';
 const Base = ConfigurableMixin(TranslatableMixin(InferrableMixin(LitElement), NS));
@@ -44,9 +45,17 @@ export class CopyToClipboard extends Base {
         display: flex;
         justify-content: center;
         align-items: center;
+        transition: color 0.15s ease;
       }
 
-      .icon-button::before {
+      .icon-button.inline {
+        width: var(--lumo-size-s);
+        height: var(--lumo-size-s);
+        margin-left: calc(0px - ((var(--lumo-size-s) - 1em) / 4));
+        margin-right: calc(0px - ((var(--lumo-size-s) - 1em) / 2));
+      }
+
+      .icon-button:not(.inline)::before {
         position: absolute;
         inset: 0;
         content: ' ';
@@ -68,11 +77,16 @@ export class CopyToClipboard extends Base {
       }
 
       @media (hover: hover) {
-        .icon-button:not(:disabled):hover {
+        .icon-button:not(:disabled):not(.inline):hover {
           cursor: pointer;
         }
 
-        .icon-button:not(:disabled):hover::before {
+        .icon-button.inline:not(:disabled):hover {
+          color: var(--lumo-body-text-color);
+          cursor: default;
+        }
+
+        .icon-button:not(:disabled):not(.inline):hover::before {
           opacity: 0.16;
         }
       }
@@ -85,7 +99,7 @@ export class CopyToClipboard extends Base {
   }
 
   /** Icon or text UI. Icon UI by default. */
-  layout: 'complete' | 'text' | 'icon' | null = null;
+  layout: 'complete' | 'text' | 'icon' | 'icon-inline' | null = null;
 
   /** VaadinButton theme for text layout. */
   theme: string | null = null;
@@ -118,11 +132,11 @@ export class CopyToClipboard extends Base {
     }
 
     return html`
-      ${layout === 'icon'
+      ${layout === 'icon' || layout === 'icon-inline'
         ? html`
             <button
               id="trigger"
-              class="icon-button"
+              class=${classMap({ 'icon-button': true, 'inline': layout === 'icon-inline' })}
               ?disabled=${this.disabled}
               @click=${this.__copy}
             >

--- a/src/elements/public/DownloadableForm/DownloadableForm.test.ts
+++ b/src/elements/public/DownloadableForm/DownloadableForm.test.ts
@@ -1,12 +1,10 @@
-import type { InternalAsyncComboBoxControl } from '../../internal/InternalAsyncComboBoxControl/InternalAsyncComboBoxControl';
 import type { FetchEvent } from '../NucleonElement/FetchEvent';
 
 import './index';
 
-import { html, expect, fixture, waitUntil } from '@open-wc/testing';
+import { html, expect, fixture } from '@open-wc/testing';
 import { DownloadableForm as Form } from './DownloadableForm';
 import { createRouter } from '../../../server/hapi/index';
-import { getTestData } from '../../../testgen/getTestData';
 import { stub } from 'sinon';
 
 describe('DownloadableForm', () => {
@@ -14,12 +12,16 @@ describe('DownloadableForm', () => {
     expect(customElements.get('foxy-internal-downloadable-form-upload-control')).to.exist;
   });
 
-  it('imports and defines foxy-internal-async-combo-box-control', () => {
-    expect(customElements.get('foxy-internal-async-combo-box-control')).to.exist;
+  it('imports and defines foxy-internal-resource-picker-control', () => {
+    expect(customElements.get('foxy-internal-resource-picker-control')).to.exist;
   });
 
   it('imports and defines foxy-internal-number-control', () => {
     expect(customElements.get('foxy-internal-number-control')).to.exist;
+  });
+
+  it('imports and defines foxy-internal-summary-control', () => {
+    expect(customElements.get('foxy-internal-summary-control')).to.exist;
   });
 
   it('imports and defines foxy-internal-text-control', () => {
@@ -28,10 +30,6 @@ describe('DownloadableForm', () => {
 
   it('imports and defines foxy-internal-form', () => {
     expect(customElements.get('foxy-internal-form')).to.exist;
-  });
-
-  it('imports and defines foxy-nucleon', () => {
-    expect(customElements.get('foxy-nucleon')).to.exist;
   });
 
   it('imports and defines itself as foxy-downloadable-form', () => {
@@ -140,7 +138,7 @@ describe('DownloadableForm', () => {
     expect(renderHeaderMethod).to.have.been.called;
   });
 
-  it('renders a foxy-internal-async-combo-box-control for item category uri', async () => {
+  it('renders a foxy-internal-resource-picker-control for item category uri', async () => {
     const router = createRouter();
 
     const element = await fixture<Form>(html`
@@ -151,52 +149,36 @@ describe('DownloadableForm', () => {
       </foxy-downloadable-form>
     `);
 
-    const control = element.renderRoot.querySelector<InternalAsyncComboBoxControl>(
-      '[infer="item-category-uri"]'
+    const control = element.renderRoot.querySelector(
+      '[infer="group-one"] foxy-internal-resource-picker-control[infer="item-category-uri"]'
     );
 
     expect(control).to.exist;
-    expect(control).to.have.attribute('item-label-path', 'name');
-    expect(control).to.have.attribute('item-value-path', '_links.self.href');
-    expect(control).to.have.attribute('item-id-path', '_links.self.href');
     expect(control).to.have.attribute('first', 'https://demo.api/hapi/item_categories');
-    expect(control).to.have.property('selectedItem', null);
-
-    control?.setValue('https://demo.api/hapi/item_categories/0');
-
-    expect(element).to.have.nested.property('form.item_category_id', 0);
-    expect(element).to.have.nested.property(
-      'form.item_category_uri',
-      'https://demo.api/hapi/item_categories/0'
-    );
-
-    const itemCategory = await getTestData('./hapi/item_categories/0', router);
-    await waitUntil(() => !!control?.selectedItem, '', { timeout: 5000 });
-    expect(control).to.have.deep.property('selectedItem', itemCategory);
   });
 
   it('renders a foxy-internal-text-control for name', async () => {
     const element = await fixture<Form>(html`<foxy-downloadable-form></foxy-downloadable-form>`);
-    const control = element.renderRoot.querySelector('[infer="name"]');
+    const control = element.renderRoot.querySelector('[infer="group-one"] [infer="name"]');
     expect(control).to.be.instanceOf(customElements.get('foxy-internal-text-control'));
   });
 
   it('renders a foxy-internal-text-control for code', async () => {
     const element = await fixture<Form>(html`<foxy-downloadable-form></foxy-downloadable-form>`);
-    const control = element.renderRoot.querySelector('[infer="code"]');
+    const control = element.renderRoot.querySelector('[infer="group-one"] [infer="code"]');
     expect(control).to.be.instanceOf(customElements.get('foxy-internal-text-control'));
   });
 
   it('renders a foxy-internal-number-control for price', async () => {
     const element = await fixture<Form>(html`<foxy-downloadable-form></foxy-downloadable-form>`);
-    const control = element.renderRoot.querySelector('[infer="price"]');
+    const control = element.renderRoot.querySelector('[infer="group-two"] [infer="price"]');
     expect(control).to.be.instanceOf(customElements.get('foxy-internal-number-control'));
     expect(control).to.have.attribute('min', '0');
   });
 
   it('renders a foxy-internal-downloadable-form-upload-control for file', async () => {
     const element = await fixture<Form>(html`<foxy-downloadable-form></foxy-downloadable-form>`);
-    const control = element.renderRoot.querySelector('[infer="upload"]');
+    const control = element.renderRoot.querySelector('[infer="group-three"] [infer="upload"]');
     expect(control).to.be.instanceOf(
       customElements.get('foxy-internal-downloadable-form-upload-control')
     );

--- a/src/elements/public/DownloadableForm/DownloadableForm.ts
+++ b/src/elements/public/DownloadableForm/DownloadableForm.ts
@@ -1,14 +1,10 @@
 import type { InternalDownloadableFormUploadControl } from './internal/InternalDownloadableFormUploadControl/InternalDownloadableFormUploadControl';
 import type { PropertyDeclarations } from 'lit-element';
 import type { TemplateResult } from 'lit-html';
-import type { NucleonElement } from '../NucleonElement';
 import type { NucleonV8N } from '../NucleonElement/types';
-import type { Resource } from '@foxy.io/sdk/core';
-import type { Rels } from '@foxy.io/sdk/backend';
 import type { Data } from './types';
 
 import { TranslatableMixin } from '../../../mixins/translatable';
-import { BooleanSelector } from '@foxy.io/sdk/core';
 import { InternalForm } from '../../internal/InternalForm/InternalForm';
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { html } from 'lit-element';
@@ -48,51 +44,33 @@ export class DownloadableForm extends Base<Data> {
   /** URL of the `fx:downloadable_item_categories` collection for the store. */
   downloadableItemCategories: string | null = null;
 
-  private readonly __downloadableItemCategoryLoaderId = 'downloadableItemCategoryLoader';
-
-  get disabledSelector(): BooleanSelector {
-    const alwaysDisabled: string[] = [];
-    const loader = this.__downloadableItemCategoryLoader;
-    if (!loader?.in('idle')) alwaysDisabled.push('item-category-uri');
-    return new BooleanSelector(`${alwaysDisabled.join(' ')}${super.disabledSelector}`);
-  }
-
   renderBody(): TemplateResult {
     return html`
       ${this.renderHeader()}
 
-      <foxy-internal-async-combo-box-control
-        item-label-path="name"
-        item-value-path="_links.self.href"
-        item-id-path="_links.self.href"
-        infer="item-category-uri"
-        first=${ifDefined(this.downloadableItemCategories ?? void 0)}
-        .selectedItem=${this.__downloadableItemCategoryLoader?.data}
-        .setValue=${(newValue: string) => {
-          this.edit({ item_category_uri: newValue });
-          const newID = parseInt(newValue.split('/').pop() ?? '');
-          if (!isNaN(newID)) this.edit({ item_category_id: newID });
-        }}
-      >
-      </foxy-internal-async-combo-box-control>
+      <foxy-internal-summary-control infer="group-one" label="" helper-text="">
+        <foxy-internal-text-control layout="summary-item" infer="name"></foxy-internal-text-control>
+        <foxy-internal-text-control layout="summary-item" infer="code"></foxy-internal-text-control>
+        <foxy-internal-resource-picker-control
+          layout="summary-item"
+          first=${ifDefined(this.downloadableItemCategories ?? void 0)}
+          infer="item-category-uri"
+          item="foxy-item-category-card"
+        >
+        </foxy-internal-resource-picker-control>
+      </foxy-internal-summary-control>
 
-      <foxy-internal-text-control infer="name"></foxy-internal-text-control>
-      <foxy-internal-text-control infer="code"></foxy-internal-text-control>
-      <foxy-internal-number-control infer="price" min="0"></foxy-internal-number-control>
+      <foxy-internal-summary-control infer="group-two" label="" helper-text="">
+        <foxy-internal-number-control layout="summary-item" infer="price" min="0">
+        </foxy-internal-number-control>
+      </foxy-internal-summary-control>
 
-      <foxy-internal-downloadable-form-upload-control infer="upload">
-      </foxy-internal-downloadable-form-upload-control>
+      <foxy-internal-summary-control infer="group-three" label="" helper-text="">
+        <foxy-internal-downloadable-form-upload-control infer="upload">
+        </foxy-internal-downloadable-form-upload-control>
+      </foxy-internal-summary-control>
 
       ${super.renderBody()}
-
-      <foxy-nucleon
-        class="hidden"
-        infer=""
-        href=${ifDefined(this.form.item_category_uri || void 0)}
-        id=${this.__downloadableItemCategoryLoaderId}
-        @update=${() => this.requestUpdate()}
-      >
-      </foxy-nucleon>
     `;
   }
 
@@ -140,10 +118,5 @@ export class DownloadableForm extends Base<Data> {
     }
 
     return data;
-  }
-
-  private get __downloadableItemCategoryLoader() {
-    type Loader = NucleonElement<Resource<Rels.ItemCategory>>;
-    return this.renderRoot.querySelector<Loader>(`#${this.__downloadableItemCategoryLoaderId}`);
   }
 }

--- a/src/elements/public/DownloadableForm/index.ts
+++ b/src/elements/public/DownloadableForm/index.ts
@@ -1,9 +1,10 @@
 import './internal/InternalDownloadableFormUploadControl/index';
-import '../../internal/InternalAsyncComboBoxControl/index';
+import '../../internal/InternalResourcePickerControl/index';
+import '../../internal/InternalSummaryControl/index';
 import '../../internal/InternalNumberControl/index';
 import '../../internal/InternalTextControl/index';
 import '../../internal/InternalForm/index';
-import '../NucleonElement/index';
+import '../ItemCategoryCard/index';
 
 import { DownloadableForm } from './DownloadableForm';
 

--- a/src/elements/public/DownloadableForm/internal/InternalDownloadableFormUploadControl/InternalDownloadableFormUploadControl.test.ts
+++ b/src/elements/public/DownloadableForm/internal/InternalDownloadableFormUploadControl/InternalDownloadableFormUploadControl.test.ts
@@ -6,7 +6,6 @@ import './index';
 import { InternalDownloadableFormUploadControl as Control } from './InternalDownloadableFormUploadControl';
 import { html, expect, fixture, waitUntil } from '@open-wc/testing';
 import { createRouter } from '../../../../../server/hapi/index';
-import { getByKey } from '../../../../../testgen/getByKey';
 import { DownloadableForm } from '../../DownloadableForm';
 import { stub } from 'sinon';
 
@@ -29,17 +28,6 @@ describe('InternalDownloadableFormUploadControl', () => {
 
   it('extends foxy-internal-control', () => {
     expect(new Control()).to.be.instanceOf(customElements.get('foxy-internal-control'));
-  });
-
-  it('renders translatable label', async () => {
-    const control = await fixture<Control>(
-      html`<foxy-internal-downloadable-form-upload-control></foxy-internal-downloadable-form-upload-control>`
-    );
-
-    const label = await getByKey(control, 'label');
-
-    expect(label).to.exist;
-    expect(label).to.have.attribute('infer', '');
   });
 
   it('renders vaadin-upload for file selection and display', async () => {
@@ -239,16 +227,5 @@ describe('InternalDownloadableFormUploadControl', () => {
     expect(upload).to.have.nested.property('files[0].progress', 100);
     expect(upload).to.have.nested.property('files[0].status', 'status_complete');
     expect(upload).to.have.nested.property('files[0].name', element.data?.file_name);
-  });
-
-  it('renders translatable helper text', async () => {
-    const control = await fixture<Control>(
-      html`<foxy-internal-downloadable-form-upload-control></foxy-internal-downloadable-form-upload-control>`
-    );
-
-    const helperText = await getByKey(control, 'helper_text');
-
-    expect(helperText).to.exist;
-    expect(helperText).to.have.attribute('infer', '');
   });
 });

--- a/src/elements/public/DownloadableForm/internal/InternalDownloadableFormUploadControl/InternalDownloadableFormUploadControl.ts
+++ b/src/elements/public/DownloadableForm/internal/InternalDownloadableFormUploadControl/InternalDownloadableFormUploadControl.ts
@@ -7,6 +7,8 @@ import { ifDefined } from 'lit-html/directives/if-defined';
 import { classMap } from '../../../../../utils/class-map';
 
 export class InternalDownloadableFormUploadControl extends InternalControl {
+  private __ignoreNextFilesChange = false;
+
   get uploadElement(): UploadElement | null {
     return this.renderRoot.querySelector<UploadElement>('vaadin-upload');
   }
@@ -57,6 +59,7 @@ export class InternalDownloadableFormUploadControl extends InternalControl {
 
     if (upload && nucleon) {
       if (nucleon.in({ idle: { snapshot: 'clean' } }) && upload.files.length === 0) {
+        this.__ignoreNextFilesChange = true;
         upload.files = [
           // @ts-expect-error type doesn't match but it's ok because vaadin docs suggest this as a solution
           {
@@ -67,6 +70,7 @@ export class InternalDownloadableFormUploadControl extends InternalControl {
           },
         ];
       } else if (nucleon.in({ idle: { template: 'clean' } })) {
+        this.__ignoreNextFilesChange = true;
         upload.files = [];
       }
     }
@@ -118,6 +122,11 @@ export class InternalDownloadableFormUploadControl extends InternalControl {
   }
 
   private __handleFilesChanged(evt: CustomEvent) {
+    if (this.__ignoreNextFilesChange) {
+      this.__ignoreNextFilesChange = false;
+      return;
+    }
+
     const upload = evt.currentTarget as UploadElement;
     const nucleon = this.nucleon as DownloadableForm | null;
 

--- a/src/elements/public/DownloadableForm/internal/InternalDownloadableFormUploadControl/InternalDownloadableFormUploadControl.ts
+++ b/src/elements/public/DownloadableForm/internal/InternalDownloadableFormUploadControl/InternalDownloadableFormUploadControl.ts
@@ -124,8 +124,6 @@ export class InternalDownloadableFormUploadControl extends InternalControl {
     const files = upload.files;
     if (files.length > 1) upload.files = [upload.files[0]];
     if (files[0]?.complete && !files[0].status) files[0].status = this.t('status_complete');
-
-    const newName = upload.files[0]?.name ?? '';
-    if (newName !== nucleon?.form.file_name) nucleon?.edit({ file_name: newName });
+    nucleon?.edit({ file_name: upload.files[0]?.name ?? '' });
   }
 }

--- a/src/elements/public/DownloadableForm/internal/InternalDownloadableFormUploadControl/InternalDownloadableFormUploadControl.ts
+++ b/src/elements/public/DownloadableForm/internal/InternalDownloadableFormUploadControl/InternalDownloadableFormUploadControl.ts
@@ -15,39 +15,22 @@ export class InternalDownloadableFormUploadControl extends InternalControl {
 
   renderControl(): TemplateResult {
     return html`
-      <section
+      <vaadin-upload
+        max-file-size="524288000"
+        max-files=${ifDefined(this.disabled || this.readonly ? '0' : '2')}
         class=${classMap({
-          'grid gap-xs group leading-xs transition-colors': true,
-          'hover-text-body': !this.disabled && !this.readonly,
-          'text-secondary': !this.disabled,
+          'foxy-downloadable-form-upload transition-colors p-0 rounded-none': true,
           'text-disabled': this.disabled,
         })}
+        method="PUT"
+        no-auto
+        ?disabled=${this.disabled}
+        ?readonly=${this.readonly}
+        .i18n=${this.__uploadI18n}
+        @files-changed=${this.__handleFilesChanged}
+        @upload-request=${this.__handleUploadRequest}
       >
-        <foxy-i18n infer="" class="font-medium text-s" key="label"></foxy-i18n>
-
-        <vaadin-upload
-          max-file-size="524288000"
-          max-files=${ifDefined(this.disabled || this.readonly ? '0' : '2')}
-          style="padding: calc((0.625em + (var(--lumo-border-radius) / 4) - 1px) - var(--lumo-space-xs)) calc(0.625em + (var(--lumo-border-radius) / 4) - 1px)"
-          class=${classMap({
-            'rounded-t-l rounded-b-l border transition-colors': true,
-            'border-dashed border-contrast-30': this.readonly,
-            'border-solid border-contrast-10': !this.readonly,
-            'group-hover-border-contrast-20': !this.disabled && !this.readonly,
-            'foxy-downloadable-form-upload': true,
-          })}
-          method="PUT"
-          no-auto
-          ?disabled=${this.disabled}
-          ?readonly=${this.readonly}
-          .i18n=${this.__uploadI18n}
-          @files-changed=${this.__handleFilesChanged}
-          @upload-request=${this.__handleUploadRequest}
-        >
-        </vaadin-upload>
-
-        <foxy-i18n infer="" class="text-xs" key="helper_text"></foxy-i18n>
-      </section>
+      </vaadin-upload>
     `;
   }
 

--- a/src/elements/public/DownloadableForm/internal/InternalDownloadableFormUploadControl/style.ts
+++ b/src/elements/public/DownloadableForm/internal/InternalDownloadableFormUploadControl/style.ts
@@ -5,7 +5,7 @@ registerStyles(
   'vaadin-upload',
   css`
     :host(.foxy-downloadable-form-upload) vaadin-upload-file {
-      padding: var(--lumo-space-xs) 0 0 0;
+      padding: var(--lumo-space-s) 0 0 0;
       line-height: var(--lumo-line-height-xs);
     }
 
@@ -22,6 +22,11 @@ registerStyles(
     :host(.foxy-downloadable-form-upload) vaadin-upload-file::part(clear-button),
     :host(.foxy-downloadable-form-upload) vaadin-upload-file::part(retry-button) {
       display: none;
+    }
+
+    :host(.foxy-downloadable-form-upload) [part='upload-button'] {
+      margin: 0;
+      border-radius: var(--lumo-border-radius-s);
     }
 
     :host(.foxy-downloadable-form-upload[disabled]) vaadin-upload-file::part(status) {

--- a/src/elements/public/GiftCardCodeForm/GiftCardCodeForm.test.ts
+++ b/src/elements/public/GiftCardCodeForm/GiftCardCodeForm.test.ts
@@ -238,6 +238,10 @@ describe('GiftCardCodeForm', () => {
 
     element.edit({ customer_id: 2 });
     expect(control.getValue()).to.equal('https://demo.api/hapi/customers/2');
+
+    const testParams = new URLSearchParams();
+    control.extendFilter?.(testParams);
+    expect(testParams.get('is_anonymous')).to.equal('false|is_anonymous=true');
   });
 
   it('renders a resource picker control for associated cart item', async () => {

--- a/src/elements/public/GiftCardCodeForm/GiftCardCodeForm.ts
+++ b/src/elements/public/GiftCardCodeForm/GiftCardCodeForm.ts
@@ -61,6 +61,12 @@ export class GiftCardCodeForm extends Base<Data> {
     return itemUrl ?? null;
   };
 
+  private readonly __customerExtendFilter = (params: URLSearchParams) => {
+    if (!params.has('is_anonymous')) {
+      params.set('is_anonymous', 'false|is_anonymous=true');
+    }
+  };
+
   private readonly __customerGetValue = () => {
     const link = this.data?._links?.['fx:customer']?.href;
     const id = this.form.customer_id;
@@ -133,6 +139,7 @@ export class GiftCardCodeForm extends Base<Data> {
         infer="customer"
         first=${ifDefined(this.__storeLoader?.data?._links['fx:customers'].href)}
         item="foxy-customer-card"
+        .extendFilter=${this.__customerExtendFilter}
         .getValue=${this.__customerGetValue}
         .setValue=${this.__customerSetValue}
         .filters=${this.__customerFilters}

--- a/src/elements/public/NativeIntegrationForm/NativeIntegrationForm.ts
+++ b/src/elements/public/NativeIntegrationForm/NativeIntegrationForm.ts
@@ -565,7 +565,7 @@ export class NativeIntegrationForm extends Base<Data> {
           <a
             target="_blank"
             class="mt-xs inline-block rounded font-medium text-error transition-colors cursor-pointer hover-opacity-80 focus-outline-none focus-ring-2 focus-ring-primary-50"
-            href="https://admin.foxycart.com"
+            href="https://wiki.foxycart.com/v/2.0/webhooks"
           >
             <foxy-i18n infer="webhook-warning" key="link_text"></foxy-i18n>
           </a>

--- a/src/elements/public/QueryBuilder/components/SimpleDateRule.ts
+++ b/src/elements/public/QueryBuilder/components/SimpleDateRule.ts
@@ -55,9 +55,12 @@ export const SimpleDateRule: SimpleRuleComponent = params => {
           return onChange({ operator: null, value: `${from}..${to}` });
         }
 
+        const newValue = value ?? new Date().toISOString();
+        const removeRange = newValue.includes('..') && newSelection !== 'range';
+
         return onChange({
           operator: newSelection === 'equal' ? null : (newSelection as Operator),
-          value: value ?? new Date().toISOString(),
+          value: removeRange ? newValue.split('..')[0] : newValue,
         });
       },
     })}

--- a/src/elements/public/QueryBuilder/components/SimpleNumberRule.ts
+++ b/src/elements/public/QueryBuilder/components/SimpleNumberRule.ts
@@ -38,16 +38,17 @@ export const SimpleNumberRule: SimpleRuleComponent = params => {
         if (newSelection === 'any') return onChange(null);
 
         if (newSelection === 'range') {
-          let parsedFrom = parseFloat(rule?.value ?? '');
-          if (isNaN(parsedFrom)) parsedFrom = 0;
+          const parsedFrom = parseFloat(rule?.value ?? '');
+          if (isNaN(parsedFrom)) return onChange({ operator: null, value: '..', invalid: true });
           return onChange({ operator: null, value: `${parsedFrom}..${parsedFrom + 10}` });
         }
 
-        const newValue = rule?.value ?? option.min?.toString() ?? '0';
+        const newValue = rule?.value ?? option.min?.toString() ?? '';
         const removeRange = newValue.includes('..') && newSelection !== 'range';
 
         return onChange({
           operator: newSelection === 'equal' ? null : (newSelection as Operator),
+          invalid: !newValue,
           value: removeRange ? newValue.split('..')[0] : newValue,
         });
       },
@@ -68,8 +69,8 @@ export const SimpleNumberRule: SimpleRuleComponent = params => {
             min,
             t,
             onChange: newValue => {
-              const to = rule?.value.split('..')[1];
-              onChange({ value: `${newValue || '0'}..${to}` });
+              const to = rule?.value.split('..')[1] ?? '';
+              onChange({ value: `${newValue}..${to}`, invalid: !newValue || !to });
             },
           })}
 
@@ -86,7 +87,7 @@ export const SimpleNumberRule: SimpleRuleComponent = params => {
             t,
             onChange: newValue => {
               const from = rule?.value.split('..')[0];
-              onChange({ value: `${from}..${newValue || '0'}` });
+              onChange({ value: `${from}..${newValue}`, invalid: !from || !newValue });
             },
           })}
         `
@@ -99,7 +100,7 @@ export const SimpleNumberRule: SimpleRuleComponent = params => {
           type: 'number',
           min,
           t,
-          onChange: newValue => onChange({ value: newValue }),
+          onChange: newValue => onChange({ value: newValue, invalid: !newValue }),
         })}
   `;
 };

--- a/src/elements/public/QueryBuilder/components/SimpleNumberRule.ts
+++ b/src/elements/public/QueryBuilder/components/SimpleNumberRule.ts
@@ -34,18 +34,21 @@ export const SimpleNumberRule: SimpleRuleComponent = params => {
         { label: 'range', value: 'range' },
       ],
       t,
-      onChange: newValue => {
-        if (newValue === 'any') return onChange(null);
+      onChange: newSelection => {
+        if (newSelection === 'any') return onChange(null);
 
-        if (newValue === 'range') {
+        if (newSelection === 'range') {
           let parsedFrom = parseFloat(rule?.value ?? '');
           if (isNaN(parsedFrom)) parsedFrom = 0;
           return onChange({ operator: null, value: `${parsedFrom}..${parsedFrom + 10}` });
         }
 
+        const newValue = rule?.value ?? option.min?.toString() ?? '0';
+        const removeRange = newValue.includes('..') && newSelection !== 'range';
+
         return onChange({
-          operator: newValue === 'equal' ? null : (newValue as Operator),
-          value: rule?.value ?? option.min?.toString() ?? '0',
+          operator: newSelection === 'equal' ? null : (newSelection as Operator),
+          value: removeRange ? newValue.split('..')[0] : newValue,
         });
       },
     })}

--- a/src/elements/public/QueryBuilder/types.ts
+++ b/src/elements/public/QueryBuilder/types.ts
@@ -31,6 +31,7 @@ export type Option = {
 
 export type Rule = {
   operator: Operator | null;
+  invalid?: boolean;
   value: string;
   name?: string;
   path: string;

--- a/src/elements/public/StoreForm/StoreForm.test.ts
+++ b/src/elements/public/StoreForm/StoreForm.test.ts
@@ -1559,6 +1559,7 @@ describe('StoreForm', () => {
     );
 
     expect(control).to.exist;
+    expect(control).to.have.attribute('visibility-toggle', 'copy');
     expect(control).to.have.attribute('layout', 'summary-item');
     expect(control).to.have.attribute('show-generator');
   });

--- a/src/elements/public/StoreForm/StoreForm.ts
+++ b/src/elements/public/StoreForm/StoreForm.ts
@@ -807,6 +807,7 @@ export class StoreForm extends Base<Data> {
 
       <foxy-internal-summary-control infer="checkout" label="" helper-text="">
         <foxy-internal-password-control
+          visibility-toggle="copy"
           layout="summary-item"
           infer="unified-order-entry-password"
           show-generator

--- a/src/elements/public/TransactionsTable/TransactionsTable.test.ts
+++ b/src/elements/public/TransactionsTable/TransactionsTable.test.ts
@@ -51,7 +51,7 @@ describe('TransactionsTable', () => {
           expect(dateRef).to.have.attribute('key', 'date');
           expect(dateRef).to.have.deep.property('options', { value: transaction.transaction_date });
           expect(linkRef).to.have.attribute('href', transaction._links['fx:receipt'].href);
-          expect(idRef).to.contain.text(transaction.id.toString());
+          expect(idRef).to.contain.text(transaction.display_id.toString());
 
           {
             const items = transaction._embedded['fx:items'];

--- a/src/elements/public/TransactionsTable/TransactionsTable.ts
+++ b/src/elements/public/TransactionsTable/TransactionsTable.ts
@@ -74,7 +74,7 @@ export class TransactionsTable extends TranslatableMixin(Table, 'transactions-ta
     cell: ctx => {
       return ctx.html`
         <span class="text-m text-secondary font-tnum" data-testclass="ids">
-          <span class="text-tertiary">ID</span> ${ctx.data.id}
+          <span class="text-tertiary">ID</span> ${ctx.data.display_id}
         </span>
       `;
     },

--- a/src/server/hapi/createDataset.ts
+++ b/src/server/hapi/createDataset.ts
@@ -465,6 +465,7 @@ export const createDataset: () => Dataset = () => ({
       customer_id: 0,
       subscription_id: 0,
       is_test: true,
+      display_id: 23455455,
       is_editable: false,
       hide_transaction: false,
       data_is_fed: true,

--- a/src/static/translations/downloadable-form/en.json
+++ b/src/static/translations/downloadable-form/en.json
@@ -16,51 +16,82 @@
       "done": "Copied to clipboard"
     }
   },
-  "item-category-uri": {
-    "label": "Item category",
-    "placeholder": "",
-    "helper_text": "The item category this product is part of (only categories with item delivery type of \"downloaded\" are displayed).",
-    "v8n_required": "Please select an item category"
+  "group-one": {
+    "name": {
+      "label": "Name",
+      "placeholder": "Required",
+      "helper_text": "",
+      "v8n_required": "Please enter a name",
+      "v8n_too_long": "Please shorten the name to 100 characters or less"
+    },
+    "code": {
+      "label": "Code (SKU)",
+      "placeholder": "Required",
+      "helper_text": "",
+      "v8n_required": "Please enter a code",
+      "v8n_too_long": "Please shorten the code to 50 characters or less"
+    },
+    "item-category-uri": {
+      "label": "Item category",
+      "helper_text": "",
+      "placeholder": "Select",
+      "value": "{{ resource.name }}",
+      "v8n_required": "Please select an item category.",
+      "dialog": {
+        "cancel": "Cancel",
+        "close": "Close",
+        "header": "Select item category",
+        "selection": {
+          "label": "",
+          "helper_text": "",
+          "pagination": {
+            "first": "First",
+            "last": "Last",
+            "next": "Next",
+            "pagination": "{{from}}-{{to}} out of {{total}}",
+            "previous": "Previous",
+            "page_number": "Page number:",
+            "select": "Select",
+            "per_page": "Items per page:",
+            "card": {
+              "spinner": {
+                "loading_busy": "Loading",
+                "loading_empty": "No item categories found",
+                "loading_error": "Unknown error"
+              }
+            }
+          }
+        }
+      }
+    }
   },
-  "name": {
-    "label": "Name",
-    "placeholder": "",
-    "helper_text": "The name of this downloadable. This will be shown to the customer in the cart.",
-    "v8n_required": "Please enter a name",
-    "v8n_too_long": "Please shorten the name to 100 characters or less"
+  "group-two": {
+    "price": {
+      "label": "Price",
+      "placeholder": "Required",
+      "helper_text": "Currency will be determined by the template set applied to the cart.",
+      "v8n_required": "Please enter a price",
+      "v8n_negative": "Downloadable products can't have a negative price"
+    }
   },
-  "code": {
-    "label": "Code",
-    "placeholder": "",
-    "helper_text": "The code for this downloadable. When adding this item to the cart, this is the code which will be used.",
-    "v8n_required": "Please enter a code",
-    "v8n_too_long": "Please shorten the code to 50 characters or less"
-  },
-  "price": {
-    "label": "Price",
-    "placeholder": "",
-    "helper_text": "The item total for this downloadable. This is the amount the customer will pay to purchase this downloadable item.",
-    "v8n_required": "Please enter a price",
-    "v8n_negative": "Downloadable products can't have a negative price"
-  },
-  "upload": {
-    "label": "File",
-    "helper_text": "Any file you'd like your customers to have access to after purchasing this item. Maximum size is 500MB.",
-    "drop_label": "or drag it here",
-    "select_label": "Select file...",
-    "cancel": "Cancel",
-    "error_too_many_files": "Too many files",
-    "error_too_large": "File is too large",
-    "status_connecting": "Connecting...",
-    "status_stalled": "Stalled",
-    "status_processing": "Processing...",
-    "status_held": "Save changes to upload",
-    "status_complete": "Available for download",
-    "remaining_prefix": "remaining time: ",
-    "remaining_unknown": "unknown remaining time",
-    "error_server_unavailable": "Server unavailable",
-    "error_unexpected_server_error": "Unexpected server error",
-    "error_forbidden": "Forbidden"
+  "group-three": {
+    "upload": {
+      "drop_label": "or drag it here (max 500MB)",
+      "select_label": "Select file",
+      "cancel": "Cancel",
+      "error_too_many_files": "Too many files",
+      "error_too_large": "File is too large",
+      "status_connecting": "Connecting...",
+      "status_stalled": "Stalled",
+      "status_processing": "Processing...",
+      "status_held": "Save changes to upload",
+      "status_complete": "Available for download",
+      "remaining_prefix": "remaining time: ",
+      "remaining_unknown": "unknown remaining time",
+      "error_server_unavailable": "Server unavailable",
+      "error_unexpected_server_error": "Unexpected server error",
+      "error_forbidden": "Forbidden"
+    }
   },
   "timestamps": {
     "date_created": "Created on",

--- a/src/static/translations/native-integration-form/en.json
+++ b/src/static/translations/native-integration-form/en.json
@@ -337,7 +337,7 @@
   },
   "webhook-warning": {
     "warning_text": "We are winding down support for custom services that rely on legacy webhooks and XML datafeed. Please consider using the new JSON webhooks instead.",
-    "link_text": "Read the announcement"
+    "link_text": "See the documentation"
   },
   "webhook-legacy-xml-group-one": {
     "label": "",

--- a/src/static/translations/store-form/en.json
+++ b/src/static/translations/store-form/en.json
@@ -296,7 +296,11 @@
       "label": "Unified order entry password",
       "placeholder": "None",
       "helper_text": "Set a master password here if you would like to be able to check out as your customers without having to know their password.",
-      "v8n_required": "Please reduce your UOE password to 100 characters"
+      "v8n_required": "Please reduce your UOE password to 100 characters",
+      "click_to_copy": "Click to copy",
+      "copying": "Copying",
+      "done": "Done",
+      "failed_to_copy": "Failed to copy"
     },
     "use-single-sign-on": {
       "label": "Enable SSO",


### PR DESCRIPTION
### Bug Fixes

* **foxy-query-builder:** fix simple query builder getting stuck on in range ([1306f9f](https://github.com/Foxy/foxy-elements/commit/1306f9f5ad9d909c5799cc026b1637fe8ee3696f))
* **foxy-gift-card-form:** update filters to account for API defaulting to non-guest customers ([bb25e01](https://github.com/Foxy/foxy-elements/commit/bb25e0143e502d76b6a1742464375fab6151595e))
* **foxy-native-integration-form:** update webhook warning link ([c7c847c](https://github.com/Foxy/foxy-elements/commit/c7c847c8144d33eb0836834728d8056aeb9e7ca1))
* **foxy-transactions-table:** use display id instead of transaction id ([5df1d55](https://github.com/Foxy/foxy-elements/commit/5df1d55d89baec279320fb840b7534d9260333e7))
* **foxy-downloadable-form:** don't report file picker changes on programmatic assignment ([9acadb8](https://github.com/Foxy/foxy-elements/commit/9acadb861630227d6ab988bf3f824b7f03eadce1))
* hide v8n errors in resource pickers until user interaction ([a166b73](https://github.com/Foxy/foxy-elements/commit/a166b73a1100785f10cd7b3e12209cd57c386c0f))


### Features

* **foxy-copy-to-clipboard:** add `icon-inline` layout ([a75c9ab](https://github.com/Foxy/foxy-elements/commit/a75c9ab3c202591c5e2bf525d3b5294d50d1ab6f))
* **foxy-query-builder:** allow invalid queries in simple mode while editing, report only when the query reaches a valid state ([9e66d80](https://github.com/Foxy/foxy-elements/commit/9e66d80dd772fd1996428b3cabb573c18234da78))
* **foxy-store-form:** Unified Order Entry UI: Change "Reveal" to "Copy" ([20ef035](https://github.com/Foxy/foxy-elements/commit/20ef03562586ffa1315690da967bf6d775aec163))
* **foxy-downloadable-form:** refresh form ui ([4c45646](https://github.com/Foxy/foxy-elements/commit/4c456464fbb2432562acdb74e7db0ab30190f328))