### PR TITLE
fix(payment-method-selector): keep the Adyen Drop-in mounted across unrelated updates

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,12 @@
+# Loaded by Vite only in test mode (Vitest's default), so it never reaches a
+# `vite build` and production still fails loudly on a missing value.
+#
+# `src/elements/foxy-payment-card-field/element.ts` reads this at module scope,
+# so without it the import throws and takes the whole file's tests with it:
+# on a clean checkout 3 of 10 test files fail to import and 55 tests run
+# instead of 169. Without a committed default the suites pass only on machines
+# that happen to have an uncommitted `.env.local`.
+#
+# Test-only placeholder. Real values belong in `.env.local`, which is
+# uncommitted because it carries live sandbox gateway credentials.
+VITE_EMBED_ORIGIN=http://localhost:5173

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Runs the same checks a CI job would, before anything leaves this machine.
+# Activated by `git config core.hooksPath .githooks`, which the package's
+# `prepare` script sets on npm install.
+#
+# Bypass with `git push --no-verify` when you need to push known-red work.
+
+exec npm run verify

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "./foxy-payment-method-selector": "./dist/npm/foxy-payment-method-selector.js"
   },
   "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc -b",
+    "verify": "npm run typecheck && npm test",
+    "prepare": "git config core.hooksPath .githooks || true",
     "extract": "formatjs extract 'src/**/*.ts*' --ignore='**/*.d.ts' --out-file src/locales/en-US.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format simple",
     "init:adyen": "node ./scripts/init-adyen-payment-methods.js",
     "init:klarna": "node ./scripts/init-klarna-session.js",

--- a/src/elements/foxy-payment-method-selector/element.test.ts
+++ b/src/elements/foxy-payment-method-selector/element.test.ts
@@ -1650,6 +1650,100 @@ describe("PaymentMethodSelectorElement", () => {
     }
   });
 
+  // The gateway config arrives in the API JSON before the Adyen SDK instance
+  // finishes resolving, so the first mount can land while
+  // `checkoutClient.adyenEmbedded` is still null. Sampling it once and giving up
+  // leaves the shopper looking at the load-error message for the rest of the
+  // session; the Drop-in has to appear when the SDK does.
+  it("mounts the Adyen Drop-in once the SDK instance becomes available", async () => {
+    const { Component: Dropin } = createAdyenComponentMock({
+      mountText: "Adyen drop-in",
+    });
+    const restoreClient = overrideClientState(
+      createAdyenEmbeddedApiState(),
+      undefined,
+      {
+        adyenEmbedded: null,
+      },
+    );
+    const element = document.createElement(
+      "foxy-payment-method-selector",
+    ) as PaymentMethodSelectorElement;
+
+    try {
+      document.body.append(element);
+      await waitForTruthy(
+        () => element.querySelector('[data-adyen-embedded-status="error"]'),
+        "Adyen load error before the SDK resolves",
+      );
+      expect(Dropin).toHaveBeenCalledTimes(0);
+
+      Object.defineProperty(checkoutClient, "adyenEmbedded", {
+        configurable: true,
+        value: { Dropin },
+      });
+      checkoutClient.dispatchEvent(new Event("update"));
+
+      await waitForTruthy(
+        () => Dropin.mock.calls.length === 1,
+        "Adyen Drop-in after the SDK resolves",
+      );
+      expect(Dropin).toHaveBeenCalledTimes(1);
+    } finally {
+      element.remove();
+      restoreClient();
+    }
+  });
+
+  // A checkout state change the Adyen config does not depend on — a billing
+  // address edit — still rebuilds the option list, and with it a fresh
+  // `adyenEmbedded` config object. If the Drop-in's mount effect keys on that
+  // object's identity it tears down and remounts, throwing away whatever the
+  // shopper has already typed into the card fields.
+  it("does not remount the Adyen Drop-in when unrelated checkout state changes", async () => {
+    const { Component: Dropin } = createAdyenComponentMock({
+      mountText: "Adyen drop-in",
+    });
+    const restoreClient = overrideClientState(
+      createAdyenEmbeddedApiState(),
+      undefined,
+      {
+        adyenEmbedded: {
+          Dropin,
+        },
+      },
+    );
+    const element = document.createElement(
+      "foxy-payment-method-selector",
+    ) as PaymentMethodSelectorElement;
+
+    try {
+      document.body.append(element);
+      await waitForTruthy(
+        () => element.querySelector("[data-foxy-adyen-host]"),
+        "Adyen light DOM host",
+      );
+      await waitForTruthy(() => Dropin.mock.calls.length === 1, "Adyen Drop-in");
+
+      const nextApiState = createAdyenEmbeddedApiState();
+      nextApiState.billing_address.city = "Saint Paul";
+      Object.defineProperty(checkoutClient, "state", {
+        configurable: true,
+        value: nextApiState,
+      });
+      checkoutClient.dispatchEvent(new Event("update"));
+
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        await waitForRender();
+      }
+
+      expect(Dropin).toHaveBeenCalledTimes(1);
+    } finally {
+      element.remove();
+      restoreClient();
+    }
+  });
+
   it("sanitizes customer-controlled theme-* attributes before injecting Adyen CSS into document.head", async () => {
     // Regression test for a CSS-injection vulnerability: `buildAdyenEmbeddedStyles`
     // used to interpolate `theme-*` attribute values (public, customer-controllable)

--- a/src/elements/foxy-payment-method-selector/embeds/ach-hosted.tsx
+++ b/src/elements/foxy-payment-method-selector/embeds/ach-hosted.tsx
@@ -129,6 +129,15 @@ export default function AchOptionEmbed({
     [option.hostedFields?.group],
   );
 
+  // `option.hostedFields` is rebuilt on every options refresh, so its identity
+  // changes whenever anything about the checkout changes. Unlike the Adyen
+  // embed this effect only re-registers listeners — nothing visible is torn
+  // down — but keying on the config's values keeps that true if it ever grows
+  // teardown logic.
+  const hostedFieldsKey = option.hostedFields
+    ? JSON.stringify(option.hostedFields)
+    : "";
+
   useEffect(() => {
     if (!option.hostedFields) return;
 
@@ -171,8 +180,8 @@ export default function AchOptionEmbed({
       onControllerReady?.(null);
     };
   }, [
+    hostedFieldsKey,
     onControllerReady,
-    option.hostedFields,
     ownerConfirmed,
     ownerConfirmationErrorMessage,
   ]);

--- a/src/elements/foxy-payment-method-selector/embeds/adyen-embedded.tsx
+++ b/src/elements/foxy-payment-method-selector/embeds/adyen-embedded.tsx
@@ -505,6 +505,30 @@ export default function AdyenEmbeddedOption({
     ensureAdyenEmbeddedStyles(tokens);
   }, [tokens]);
 
+  // Same reasoning as `tokens` above, one level down: `option.adyenEmbedded` is
+  // rebuilt from the API state on every options refresh (see element.tsx's
+  // #createAdyenEmbeddedConfig), so its identity changes whenever *anything*
+  // about the checkout changes — a billing address edit included. Keying the
+  // mount effect on the config's values instead keeps the Drop-in, and whatever
+  // the shopper has already typed into it, alive across those refreshes.
+  const adyenConfigKey = option.adyenEmbedded
+    ? JSON.stringify([
+        option.adyenEmbedded.environment,
+        option.adyenEmbedded.clientKey,
+        option.adyenEmbedded.paymentMethodsResponse,
+      ])
+    : "";
+
+  // Read during render rather than sampled inside the effect below. The gateway
+  // config reaches this element through the API JSON before the Adyen SDK
+  // instance finishes resolving, so the first mount can land while this is still
+  // null — and an effect that only sampled it would latch the load error for the
+  // rest of the session. As a dependency it re-runs the mount when the SDK
+  // arrives instead. The SDK caches the instance per configuration, so this does
+  // not reintroduce the identity churn `adyenConfigKey` exists to avoid.
+  const checkout =
+    (checkoutClient as CheckoutClientLike).adyenEmbedded ?? null;
+
   useEffect(() => {
     const adyenOption = option.adyenEmbedded;
     const container = containerRef.current;
@@ -518,7 +542,6 @@ export default function AdyenEmbeddedOption({
 
     if (!adyenOption || !container) return;
 
-    const checkout = (checkoutClient as CheckoutClientLike).adyenEmbedded;
     const Component = checkout
       ? getAdyenComponentConstructor(checkout, "Dropin")
       : undefined;
@@ -709,11 +732,12 @@ export default function AdyenEmbeddedOption({
       }
     };
   }, [
+    adyenConfigKey,
+    checkout,
     disabled,
     loadErrorMessage,
     onControllerReady,
     onSelect,
-    option.adyenEmbedded,
     option.id,
     submitErrorMessage,
     unavailableMessage,


### PR DESCRIPTION
FX-179, the foxy-elements half. The root cause of the re-render storm was in foxy-sdk (Foxy/foxy-sdk#77); these are two real defects in this repo that it uncovered.

## 1. Remount on unrelated state changes

`option.adyenEmbedded` is rebuilt on every options refresh, so its identity changed whenever anything about the checkout changed. The mount effect keyed on that identity, so editing the billing address tore the Drop-in down and rebuilt it — **discarding whatever the shopper had typed into the card fields**.

Measured in a new test: the Drop-in constructor ran twice where it should run once. The effect now keys on a value signature of the config (`environment`, `clientKey`, `paymentMethodsResponse`).

## 2. A pre-existing race that fix 1 exposed

With the churn gone, the Drop-in showed "Unable to load this payment method" on every fresh load. On the store, `window.AdyenWeb.Dropin` and `client.adyenEmbedded` were both fine *after* load, and detaching/re-attaching the element rendered it correctly — the SDK simply was not ready at first mount.

The gateway config reaches this element through the API JSON before `initializeAdyenEmbeddedSdk` resolves, so the first mount can land while `checkoutClient.adyenEmbedded` is still null. The effect sampled it once and latched `status: error` for the session. The update storm had been re-running that effect until it happened to succeed — an accidental retry — so removing the churn made the race visible.

**This is very likely the "renders incorrectly" symptom the issue was filed for.** Anyone who fixed the storm would have hit it.

`adyenEmbedded` is now read during render and is a dependency, so the mount re-runs when the SDK arrives. The SDK caches the instance per configuration, so no identity churn returns — the fix-1 test still passing is what proves the two do not conflict.

## Verified on the dev store

Fresh load: `status: ready`, card form rendered, 0 update events.

Billing city edited through the real UI (`Minneapolis` → `Saint Paul`, confirmed in `client.json`):

- 3 update events, legitimate and bounded
- all 4 Adyen secured-field iframes were the **same DOM objects** afterwards
- the Drop-in root survived, status stayed `ready`

Same iframe objects means typed card data survives an address edit.

## Also here

- An ACH embed refactor to the same value-keyed pattern. Investigated first and found **no user-visible defect** — that effect only re-registers listeners — so no test was possible and none is added. It is a guard, not a fix; happy to drop it if you would rather not carry it.
- A `verify` script and pre-push hook (FX-252), plus this repo's first `test` script — tests previously only ran if you knew to type `vitest run --project=unit`.
- A committed `.env.test`. The suites passed only on machines with an uncommitted `.env.local`: measured with it moved aside, 3 of 10 test files fail to import and 55 tests run instead of 169. Same fix foxy-checkout took in FX-230.

Unit 152 + storybook 17 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)