### PR TITLE
fix(payment-method-selector): keep docs and stories in one sidebar group (FX-175) [agent]

### DIFF
--- a/src/elements/foxy-payment-method-selector/docs.mdx
+++ b/src/elements/foxy-payment-method-selector/docs.mdx
@@ -1,6 +1,7 @@
 import { Meta } from "@storybook/blocks";
+import * as PaymentMethodSelectorStories from "./element.stories";
 
-<Meta title="Checkout/foxy-payment-method-selector" name="Docs" />
+<Meta of={PaymentMethodSelectorStories} name="Docs" />
 
 # foxy-payment-method-selector
 

--- a/src/elements/foxy-payment-method-selector/element.stories.ts
+++ b/src/elements/foxy-payment-method-selector/element.stories.ts
@@ -30,7 +30,9 @@ type SelectorStoryArgs = {
 };
 
 const meta = {
-  title: "Universal/foxy-payment-method-selector",
+  // Keeps the element in the sidebar section its docs page already used. The
+  // two hosted-field elements are Universal; this one is checkout-specific.
+  title: "Checkout/foxy-payment-method-selector",
   parameters: {
     layout: "centered",
     actions: {


### PR DESCRIPTION
https://linear.app/foxyio/issue/FX-175

Draft. Opened automatically by an agent routine; details are on the linked issue.