### PR TITLE
test(payment-method-selector): cover the six untested option embeds (FX-176) [agent]

### DIFF
--- a/src/elements/foxy-ach-field/element.test.ts
+++ b/src/elements/foxy-ach-field/element.test.ts
@@ -193,6 +193,54 @@ describe("AchFieldElement events", () => {
     vi.restoreAllMocks();
   });
 
+  // FX-264: the setter returned early when the assigned value already matched
+  // the element's state, before it reached `setAttribute`. `routing-number` is
+  // the default, so assigning it reflected nothing and the field stayed
+  // unreachable by `foxy-ach-field[type="routing-number"]`.
+  it("reflects type to an attribute even when the value is the element's default", () => {
+    const field = createField("routing-number");
+
+    expect(field.getAttribute("type")).toBe("routing-number");
+    expect(
+      document.querySelectorAll('foxy-ach-field[type="routing-number"]'),
+    ).toHaveLength(1);
+  });
+
+  it("reflects type before the element is connected", () => {
+    const field = document.createElement(
+      ACH_FIELD_ELEMENT_TAG,
+    ) as AchFieldElement;
+
+    field.type = "routing-number";
+
+    expect(field.isConnected).toBe(false);
+    expect(field.getAttribute("type")).toBe("routing-number");
+  });
+
+  it("keeps reflecting a type change away from and back to the default", () => {
+    const field = createField("routing-number");
+
+    field.type = "account-number";
+    expect(field.getAttribute("type")).toBe("account-number");
+    expect(field.type).toBe("account-number");
+
+    field.type = "routing-number";
+    expect(field.getAttribute("type")).toBe("routing-number");
+    expect(field.type).toBe("routing-number");
+  });
+
+  // An unrecognised value falls back to the default, which is exactly the case
+  // the old early return swallowed: state and attribute both have to end up on
+  // the fallback.
+  it("reflects the fallback type when the assigned value is not a field name", () => {
+    const field = createField("account-number");
+
+    field.type = "not-a-field" as AchFieldElement["type"];
+
+    expect(field.type).toBe("routing-number");
+    expect(field.getAttribute("type")).toBe("routing-number");
+  });
+
   it("dispatches change only for field instances whose values changed", () => {
     const routing = createField("routing-number");
     const account = createField("account-number", routing.group);

--- a/src/elements/foxy-ach-field/element.ts
+++ b/src/elements/foxy-ach-field/element.ts
@@ -640,9 +640,16 @@ export class AchFieldElement extends ThemeableHTMLElement {
 
   set type(value: AchHostedFieldName) {
     const normalized = isAchFieldName(value) ? value : "routing-number";
-    if (normalized === this._type) return;
+    const changed = normalized !== this._type;
 
-    this._type = normalized;
+    if (changed) this._type = normalized;
+
+    // Reflected even when the state did not change. `routing-number` is this
+    // element's own default, so assigning it is a no-op for state — and
+    // returning here would leave the field with no `type` attribute at all,
+    // invisible to attribute selectors, CSS and devtools. Assigned before the
+    // write so attributeChangedCallback sees the state it is about to be told
+    // about and stops.
     if (this.getAttribute(TYPE_ATTRIBUTE) !== normalized) {
       this.setAttribute(TYPE_ATTRIBUTE, normalized);
     }

--- a/src/elements/foxy-payment-card-field/element.test.ts
+++ b/src/elements/foxy-payment-card-field/element.test.ts
@@ -239,7 +239,10 @@ describe("PaymentCardFieldElement", () => {
     const element = document.createElement(
       PAYMENT_CARD_FIELD_ELEMENT_TAG,
     ) as PaymentCardFieldElement;
-    element.style.setProperty("--font-body", "400 1rem/1.25 Figtree, sans-serif");
+    element.style.setProperty(
+      "--font-body",
+      "400 1rem/1.25 Figtree, sans-serif",
+    );
     element.style.setProperty("--size-control", "4rem");
     document.body.append(element);
 
@@ -259,7 +262,9 @@ describe("PaymentCardFieldElement", () => {
       window.location.origin,
     );
     expect(url.searchParams.get("theme_font_sans")).toBe("Figtree, sans-serif");
-    expect(url.searchParams.get("theme_input_height")).toBe(`${expectedHeightPx}px`);
+    expect(url.searchParams.get("theme_input_height")).toBe(
+      `${expectedHeightPx}px`,
+    );
   });
 
   it("falls back to card mode for unsupported mode values", () => {
@@ -271,6 +276,67 @@ describe("PaymentCardFieldElement", () => {
 
     expect(element.mode).toBe("card");
     expect(element.getAttribute("mode")).toBe("card");
+  });
+
+  // FX-264: the setter returned early when the assigned value already matched
+  // the element's state, before it reached `setAttribute`. `card` is the
+  // default, so assigning it reflected nothing and the field stayed unreachable
+  // by `foxy-payment-card-field[mode="card"]`.
+  it("reflects mode to an attribute even when the value is the element's default", () => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+    document.body.append(element);
+
+    element.mode = "card";
+
+    expect(element.getAttribute("mode")).toBe("card");
+    expect(
+      document.querySelectorAll('foxy-payment-card-field[mode="card"]'),
+    ).toHaveLength(1);
+  });
+
+  it("reflects mode before the element is connected", () => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+
+    element.mode = "card";
+
+    expect(element.isConnected).toBe(false);
+    expect(element.getAttribute("mode")).toBe("card");
+  });
+
+  // Reflecting the no-op assignment must not cost a second iframe mount: the
+  // attribute write reaches attributeChangedCallback, which remounts whenever
+  // it sees a genuinely new mode.
+  it("does not remount the iframe when mode is reassigned its current value", () => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+    document.body.append(element);
+
+    const before = element.shadowRoot?.querySelector("iframe");
+    expect(before).toBeTruthy();
+
+    element.mode = "card";
+
+    expect(element.shadowRoot?.querySelector("iframe")).toBe(before);
+  });
+
+  it("keeps reflecting a mode change away from and back to the default", () => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+    document.body.append(element);
+
+    element.mode = "card_csc";
+    expect(element.getAttribute("mode")).toBe("card_csc");
+    expect(element.mode).toBe("card_csc");
+
+    element.mode = "card";
+    expect(element.getAttribute("mode")).toBe("card");
+    expect(element.mode).toBe("card");
   });
 
   it("uses VITE_EMBED_ORIGIN to build the iframe URL", () => {

--- a/src/elements/foxy-payment-card-field/element.ts
+++ b/src/elements/foxy-payment-card-field/element.ts
@@ -313,12 +313,21 @@ export class PaymentCardFieldElement extends ThemeableHTMLElement {
 
   set mode(value: PaymentCardFieldMode) {
     const normalized = normalizeMode(value);
-    if (this._mode === normalized) return;
+    const changed = this._mode !== normalized;
 
-    this._mode = normalized;
+    if (changed) this._mode = normalized;
+
+    // Reflected even when the state did not change. `card` is this element's
+    // own default, so assigning it is a no-op for state — and returning here
+    // would leave the field with no `mode` attribute at all, invisible to
+    // attribute selectors, CSS and devtools. Assigned before the write so
+    // attributeChangedCallback sees the state it is about to be told about and
+    // stops, which is what keeps the iframe from mounting twice.
     if (this.getAttribute(MODE_ATTRIBUTE) !== normalized) {
       this.setAttribute(MODE_ATTRIBUTE, normalized);
     }
+
+    if (!changed) return;
 
     this._syncAggregateValidity();
     if (this.isConnected) this._mountIframe();

--- a/src/elements/foxy-payment-method-selector/embeds/ach-hosted.test.ts
+++ b/src/elements/foxy-payment-method-selector/embeds/ach-hosted.test.ts
@@ -1,0 +1,320 @@
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import type {
+  AchFieldElement,
+  AchHostedFieldName,
+} from "../../foxy-ach-field/element";
+import type { HostedFieldStyleAttributes } from "../stripe/style-hooks";
+import type { PaymentController, PaymentMethodSelectorOption } from "../types";
+import AchOptionEmbed from "./ach-hosted";
+import {
+  controllerSink,
+  mountEmbed,
+  optionWith,
+  rejection,
+  settled,
+} from "./test-utils";
+
+const OWNER_CONFIRMATION_LABEL = "I am the account owner.";
+const OWNER_CONFIRMATION_ERROR = "Confirm that you own this account.";
+const TOKENIZE_ERROR = "We could not verify those bank details.";
+
+const DEFAULT_LABELS: Partial<Record<AchHostedFieldName, string>> = {
+  "routing-number": "Routing number",
+  "account-number": "Account number",
+  "account-type": "Account type",
+  "account-holder-name": "Account holder name",
+};
+
+const STYLE_ATTRIBUTES: HostedFieldStyleAttributes = {
+  inputBackground: "#ffffff",
+  inputPlaceholderColor: "#8a8a8a",
+  inputFont: "400 1rem/1.5 Inter, sans-serif",
+  inputTextColor: "#111111",
+  inputTextColorError: "#cc0000",
+};
+
+type EmbedPropOverrides = {
+  hostedFields?: PaymentMethodSelectorOption["hostedFields"] | false;
+  disabled?: boolean;
+  onControllerReady?: (controller: PaymentController | null) => void;
+};
+
+function embed(overrides: EmbedPropOverrides = {}) {
+  return createElement(AchOptionEmbed, {
+    option: optionWith({
+      id: "ach",
+      hostedFields:
+        overrides.hostedFields === false
+          ? undefined
+          : (overrides.hostedFields ?? { group: "test-group" }),
+    }),
+    disabled: overrides.disabled,
+    styleAttributes: STYLE_ATTRIBUTES,
+    onControllerReady: overrides.onControllerReady,
+    defaultLabelsByField: DEFAULT_LABELS,
+    ownerConfirmationLabel: OWNER_CONFIRMATION_LABEL,
+    ownerConfirmationErrorMessage: OWNER_CONFIRMATION_ERROR,
+    tokenizeErrorMessage: TOKENIZE_ERROR,
+  });
+}
+
+function fieldsIn(container: HTMLElement): AchFieldElement[] {
+  return [...container.querySelectorAll<AchFieldElement>("foxy-ach-field")];
+}
+
+/**
+ * Selects by the element's `type` property rather than its attribute. The
+ * attribute is only written when the value differs from the element's default
+ * (`routing-number`), so the routing-number field carries no `type` attribute
+ * at all — see the reflection test below.
+ */
+function fieldIn(
+  container: HTMLElement,
+  type: AchHostedFieldName,
+): AchFieldElement {
+  const field = fieldsIn(container).find(
+    (candidate) => candidate.type === type,
+  );
+
+  if (!field) throw new Error(`The ${type} field did not render.`);
+  return field;
+}
+
+function ownerConfirmationIn(container: HTMLElement): HTMLElement {
+  const checkbox = container.querySelector<HTMLElement>(
+    '[data-ach-owner-confirmation="true"]',
+  );
+
+  if (!checkbox) throw new Error("The owner confirmation did not render.");
+  return checkbox;
+}
+
+/**
+ * Replaces a hosted field's `tokenize` with a stub. The real one talks to the
+ * embed iframe, which never answers here; what these tests check is the gate
+ * the embed puts in front of it.
+ */
+function stubTokenize(field: AchFieldElement, result: unknown): void {
+  Object.defineProperty(field, "tokenize", {
+    configurable: true,
+    value: async () => result,
+  });
+}
+
+describe("AchOptionEmbed", () => {
+  it("renders nothing when the option carries no hosted field config", async () => {
+    const mounted = await mountEmbed(embed({ hostedFields: false }));
+
+    expect(fieldsIn(mounted.container)).toHaveLength(0);
+
+    await mounted.unmount();
+  });
+
+  it("renders the four hosted fields in one group", async () => {
+    const mounted = await mountEmbed(
+      embed({ hostedFields: { group: "group-1" } }),
+    );
+
+    const fields = fieldsIn(mounted.container);
+
+    expect(fields.map((field) => field.type)).toEqual([
+      "routing-number",
+      "account-number",
+      "account-type",
+      "account-holder-name",
+    ]);
+    // One group is what makes the four iframes tokenize as a single set.
+    expect(new Set(fields.map((field) => field.getAttribute("group")))).toEqual(
+      new Set(["group-1"]),
+    );
+
+    await mounted.unmount();
+  });
+
+  // Without a configured group the fields would each get their own id and
+  // tokenize separately, so the embed generates one and shares it.
+  it("generates a shared group when the config carries none", async () => {
+    const mounted = await mountEmbed(embed({ hostedFields: {} }));
+
+    const groups = fieldsIn(mounted.container).map((field) =>
+      field.getAttribute("group"),
+    );
+
+    expect(groups[0]).toBeTruthy();
+    expect(new Set(groups).size).toBe(1);
+
+    await mounted.unmount();
+  });
+
+  it("prefers the option's labels over the host defaults", async () => {
+    const mounted = await mountEmbed(
+      embed({
+        hostedFields: {
+          group: "group-1",
+          labels: { "routing-number": "ABA number" },
+        },
+      }),
+    );
+
+    const labels = [...mounted.container.querySelectorAll("label")].map(
+      (label) => label.textContent,
+    );
+
+    expect(labels).toContain("ABA number");
+    expect(labels).toContain(DEFAULT_LABELS["account-number"]);
+    expect(labels).not.toContain(DEFAULT_LABELS["routing-number"]);
+
+    await mounted.unmount();
+  });
+
+  it("forwards placeholders and account type values from the config", async () => {
+    const mounted = await mountEmbed(
+      embed({
+        hostedFields: {
+          group: "group-1",
+          placeholders: { "account-number": "000123456789" },
+          accountTypeValues: ["checking", "savings"],
+        },
+      }),
+    );
+
+    expect(
+      fieldIn(mounted.container, "account-number").getAttribute("placeholder"),
+    ).toBe("000123456789");
+    // Only the account-type field takes the list; the others must not carry it.
+    expect(
+      fieldIn(mounted.container, "account-type").getAttribute(
+        "account-type-values",
+      ),
+    ).toBe("checking,savings");
+    expect(
+      fieldIn(mounted.container, "routing-number").hasAttribute(
+        "account-type-values",
+      ),
+    ).toBe(false);
+
+    await mounted.unmount();
+  });
+
+  it("forwards the disabled state to every field and to the confirmation", async () => {
+    const mounted = await mountEmbed(embed({ disabled: true }));
+
+    for (const field of fieldsIn(mounted.container)) {
+      expect(field.disabled).toBe(true);
+    }
+
+    // The design system's checkbox is a span with the checkbox role, so being
+    // disabled shows up as `aria-disabled`, not the `disabled` property.
+    expect(
+      ownerConfirmationIn(mounted.container).getAttribute("aria-disabled"),
+    ).toBe("true");
+
+    await mounted.unmount();
+  });
+
+  // Documents current behaviour rather than endorsing it: `foxy-ach-field`'s
+  // `type` setter returns early when the value already matches, and the field
+  // defaults to `routing-number`, so React assigning that same value never
+  // reaches `setAttribute`. The result is one field out of four with no `type`
+  // attribute, which an attribute selector cannot see. Update this test when
+  // the reflection is made unconditional; do not delete it.
+  it("reflects type to an attribute for every field except the default one", async () => {
+    const mounted = await mountEmbed(embed());
+
+    expect(
+      fieldIn(mounted.container, "routing-number").hasAttribute("type"),
+    ).toBe(false);
+    expect(
+      fieldIn(mounted.container, "account-number").getAttribute("type"),
+    ).toBe("account-number");
+
+    await mounted.unmount();
+  });
+
+  // ACH debits need the account owner's authorization, so the embed refuses to
+  // tokenize before the shopper confirms — and says why, rather than failing
+  // silently.
+  it("refuses to tokenize until the owner confirmation is checked", async () => {
+    const sink = controllerSink();
+    const mounted = await mountEmbed(
+      embed({ onControllerReady: sink.onControllerReady }),
+    );
+
+    stubTokenize(fieldIn(mounted.container, "routing-number"), {
+      token: "tok_ach",
+    });
+
+    const error = await rejection(() => sink.get().tokenize());
+
+    expect(error.message).toBe(OWNER_CONFIRMATION_ERROR);
+    expect(mounted.container.textContent).toContain(OWNER_CONFIRMATION_ERROR);
+
+    await mounted.unmount();
+  });
+
+  it("tokenizes through the first mounted field once the owner confirms", async () => {
+    const sink = controllerSink();
+    const mounted = await mountEmbed(
+      embed({ onControllerReady: sink.onControllerReady }),
+    );
+
+    // The whole group tokenizes through whichever field answers first, so the
+    // stub goes on the first one the embed finds.
+    stubTokenize(fieldIn(mounted.container, "routing-number"), {
+      token: "tok_ach",
+      requestId: "req_ach",
+    });
+
+    await settled(() => {
+      ownerConfirmationIn(mounted.container).click();
+    });
+
+    await expect(settled(() => sink.get().tokenize())).resolves.toEqual({
+      token: "tok_ach",
+      requestId: "req_ach",
+    });
+    expect(mounted.container.textContent).not.toContain(
+      OWNER_CONFIRMATION_ERROR,
+    );
+
+    await mounted.unmount();
+  });
+
+  it("shows the tokenize error message on a tokenizationerror event and clears it on success", async () => {
+    const mounted = await mountEmbed(embed());
+    const field = fieldIn(mounted.container, "routing-number");
+
+    await settled(() => {
+      field.dispatchEvent(
+        new CustomEvent("tokenizationerror", {
+          detail: { code: "invalid_routing_number" },
+        }),
+      );
+    });
+
+    expect(mounted.container.textContent).toContain(TOKENIZE_ERROR);
+
+    await settled(() => {
+      field.dispatchEvent(new CustomEvent("tokenizationsuccess", {}));
+    });
+
+    expect(mounted.container.textContent).not.toContain(TOKENIZE_ERROR);
+
+    await mounted.unmount();
+  });
+
+  it("hands the host a controller on mount and clears it on unmount", async () => {
+    const sink = controllerSink();
+    const mounted = await mountEmbed(
+      embed({ onControllerReady: sink.onControllerReady }),
+    );
+
+    expect(sink.get().tokenize).toBeTypeOf("function");
+
+    await mounted.unmount();
+
+    expect(sink.latest()).toBeNull();
+  });
+});

--- a/src/elements/foxy-payment-method-selector/embeds/ach-hosted.test.ts
+++ b/src/elements/foxy-payment-method-selector/embeds/ach-hosted.test.ts
@@ -214,21 +214,24 @@ describe("AchOptionEmbed", () => {
     await mounted.unmount();
   });
 
-  // Documents current behaviour rather than endorsing it: `foxy-ach-field`'s
-  // `type` setter returns early when the value already matches, and the field
-  // defaults to `routing-number`, so React assigning that same value never
-  // reaches `setAttribute`. The result is one field out of four with no `type`
-  // attribute, which an attribute selector cannot see. Update this test when
-  // the reflection is made unconditional; do not delete it.
-  it("reflects type to an attribute for every field except the default one", async () => {
+  // The routing-number field is the one that used to be missing its attribute:
+  // it is `foxy-ach-field`'s default type, and the setter returned early on a
+  // matching value before it reached `setAttribute`, so React assigning that
+  // same value reflected nothing (FX-264).
+  it("reflects type to an attribute for every field, including the default one", async () => {
     const mounted = await mountEmbed(embed());
 
     expect(
-      fieldIn(mounted.container, "routing-number").hasAttribute("type"),
-    ).toBe(false);
+      fieldIn(mounted.container, "routing-number").getAttribute("type"),
+    ).toBe("routing-number");
     expect(
       fieldIn(mounted.container, "account-number").getAttribute("type"),
     ).toBe("account-number");
+    // The reason the attribute matters: this is how a stylesheet or a test
+    // reaches one specific field.
+    expect(
+      mounted.container.querySelectorAll("foxy-ach-field[type]"),
+    ).toHaveLength(4);
 
     await mounted.unmount();
   });

--- a/src/elements/foxy-payment-method-selector/embeds/card-hosted.test.ts
+++ b/src/elements/foxy-payment-method-selector/embeds/card-hosted.test.ts
@@ -1,0 +1,236 @@
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import type { PaymentCardFieldElement } from "../../foxy-payment-card-field/element";
+import type { HostedFieldStyleAttributes } from "../stripe/style-hooks";
+import type { PaymentController } from "../types";
+import CardOptionEmbed from "./card-hosted";
+import {
+  controllerSink,
+  mountEmbed,
+  optionWith,
+  rejection,
+  settled,
+} from "./test-utils";
+
+const FULL_FIELD_LABEL = "Card details";
+const CSC_FIELD_LABEL = "Security code";
+const TOKENIZE_ERROR = "We could not read that card.";
+
+const STYLE_ATTRIBUTES: HostedFieldStyleAttributes = {
+  inputBackground: "#ffffff",
+  inputPlaceholderColor: "#8a8a8a",
+  inputFont: "400 1rem/1.5 Inter, sans-serif",
+  inputTextColor: "#111111",
+  inputTextColorError: "#cc0000",
+};
+
+type EmbedPropOverrides = {
+  mode?: "card" | "card_csc";
+  templateSetId?: number;
+  hostedCard?: false;
+  disabled?: boolean;
+  onControllerReady?: (controller: PaymentController | null) => void;
+};
+
+function embed(overrides: EmbedPropOverrides = {}) {
+  return createElement(CardOptionEmbed, {
+    option: optionWith({
+      id: "hosted-card",
+      hostedCard:
+        overrides.hostedCard === false
+          ? undefined
+          : {
+              mode: overrides.mode ?? "card",
+              templateSetId: overrides.templateSetId,
+            },
+    }),
+    disabled: overrides.disabled,
+    styleAttributes: STYLE_ATTRIBUTES,
+    onControllerReady: overrides.onControllerReady,
+    fullFieldLabel: FULL_FIELD_LABEL,
+    cscFieldLabel: CSC_FIELD_LABEL,
+    tokenizeErrorMessage: TOKENIZE_ERROR,
+  });
+}
+
+function fieldIn(container: HTMLElement): PaymentCardFieldElement {
+  const field = container.querySelector<PaymentCardFieldElement>(
+    "foxy-payment-card-field",
+  );
+
+  if (!field) throw new Error("The hosted card field did not render.");
+  return field;
+}
+
+/**
+ * Replaces the hosted field's `tokenize` with a stub. The real one posts to the
+ * embed iframe and waits for it to answer, which never happens here — and the
+ * point of these tests is the mapping the embed does around that call, not the
+ * hosted field's own protocol (covered by its element test).
+ */
+function stubTokenize(
+  field: PaymentCardFieldElement,
+  result: Partial<Awaited<ReturnType<PaymentCardFieldElement["tokenize"]>>>,
+): void {
+  Object.defineProperty(field, "tokenize", {
+    configurable: true,
+    value: async () => result,
+  });
+}
+
+describe("CardOptionEmbed", () => {
+  it("renders nothing when the option carries no hosted card config", async () => {
+    const mounted = await mountEmbed(embed({ hostedCard: false }));
+
+    expect(
+      mounted.container.querySelector("foxy-payment-card-field"),
+    ).toBeNull();
+
+    await mounted.unmount();
+  });
+
+  it("pushes the option's mode and template set onto the hosted field", async () => {
+    const mounted = await mountEmbed(
+      embed({ mode: "card_csc", templateSetId: 42 }),
+    );
+
+    const field = fieldIn(mounted.container);
+
+    expect(field.mode).toBe("card_csc");
+    expect(field.templateSetId).toBe(42);
+
+    await mounted.unmount();
+  });
+
+  // The two modes collect different things — a whole card versus three or four
+  // digits — so a shopper re-entering a security code must not be asked for
+  // "Card details".
+  it("labels the field by mode", async () => {
+    const mounted = await mountEmbed(embed({ mode: "card" }));
+
+    expect(mounted.container.querySelector("label")?.textContent).toBe(
+      FULL_FIELD_LABEL,
+    );
+    expect(fieldIn(mounted.container).hasAttribute("data-csc-only")).toBe(
+      false,
+    );
+
+    await mounted.render(embed({ mode: "card_csc" }));
+
+    expect(mounted.container.querySelector("label")?.textContent).toBe(
+      CSC_FIELD_LABEL,
+    );
+    // The width cap is keyed off this attribute rather than the element's own
+    // reflected `mode`, which stays absent while the mode is the default.
+    expect(fieldIn(mounted.container).getAttribute("data-csc-only")).toBe(
+      "true",
+    );
+
+    await mounted.unmount();
+  });
+
+  it("forwards the disabled state to the hosted field", async () => {
+    const mounted = await mountEmbed(embed({ disabled: true }));
+
+    expect(fieldIn(mounted.container).disabled).toBe(true);
+
+    await mounted.unmount();
+  });
+
+  it("passes the resolved style attributes through to the hosted field", async () => {
+    const mounted = await mountEmbed(embed());
+
+    const field = fieldIn(mounted.container);
+
+    expect(field.getAttribute("theme-background-field")).toBe(
+      STYLE_ATTRIBUTES.inputBackground,
+    );
+    expect(field.getAttribute("theme-color-error")).toBe(
+      STYLE_ATTRIBUTES.inputTextColorError,
+    );
+
+    await mounted.unmount();
+  });
+
+  it("maps a successful tokenization onto the selector's payload shape", async () => {
+    const sink = controllerSink();
+    const mounted = await mountEmbed(
+      embed({ onControllerReady: sink.onControllerReady }),
+    );
+
+    stubTokenize(fieldIn(mounted.container), {
+      token: "tok_123",
+      requestId: "req_123",
+      cardBrand: "visa",
+      last4: "4242",
+      expirationMonth: 12,
+      expirationYear: 2030,
+    });
+
+    await expect(settled(() => sink.get().tokenize())).resolves.toEqual({
+      token: "tok_123",
+      requestId: "req_123",
+      cardBrand: "visa",
+      last4: "4242",
+      expirationMonth: 12,
+      expirationYear: 2030,
+    });
+
+    await mounted.unmount();
+  });
+
+  // The checkout correlates the submit request with the tokenization by request
+  // id. Without one it cannot tell which token belongs to which attempt, so the
+  // embed refuses the payload rather than submitting an uncorrelated token.
+  it("refuses a tokenization response with no request id", async () => {
+    const sink = controllerSink();
+    const mounted = await mountEmbed(
+      embed({ onControllerReady: sink.onControllerReady }),
+    );
+
+    stubTokenize(fieldIn(mounted.container), { token: "tok_123" });
+
+    const error = await rejection(() => sink.get().tokenize());
+
+    expect(error.message).toContain("request id");
+
+    await mounted.unmount();
+  });
+
+  it("shows the tokenize error message on a tokenizationerror event and clears it on success", async () => {
+    const mounted = await mountEmbed(embed());
+    const field = fieldIn(mounted.container);
+
+    await settled(() => {
+      field.dispatchEvent(
+        new CustomEvent("tokenizationerror", {
+          detail: { code: "card_declined" },
+        }),
+      );
+    });
+
+    expect(mounted.container.textContent).toContain(TOKENIZE_ERROR);
+
+    await settled(() => {
+      field.dispatchEvent(new CustomEvent("tokenizationsuccess", {}));
+    });
+
+    expect(mounted.container.textContent).not.toContain(TOKENIZE_ERROR);
+
+    await mounted.unmount();
+  });
+
+  it("hands the host a controller on mount and clears it on unmount", async () => {
+    const sink = controllerSink();
+    const mounted = await mountEmbed(
+      embed({ onControllerReady: sink.onControllerReady }),
+    );
+
+    expect(sink.get().tokenize).toBeTypeOf("function");
+
+    await mounted.unmount();
+
+    expect(sink.latest()).toBeNull();
+  });
+});

--- a/src/elements/foxy-payment-method-selector/embeds/klarna.test.ts
+++ b/src/elements/foxy-payment-method-selector/embeds/klarna.test.ts
@@ -1,0 +1,290 @@
+import { createElement } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { client as checkoutClient } from "@foxy.io/sdk/checkout/client";
+
+import type { PaymentMethodSelectorKlarnaConfig } from "../types";
+import KlarnaOptionEmbed from "./klarna";
+import { flush, mountEmbed, optionWith } from "./test-utils";
+
+const LOADING_MESSAGE = "Loading Klarna…";
+const UNAVAILABLE_MESSAGE = "Klarna is not available for this order.";
+const LOAD_ERROR_MESSAGE = "Klarna could not be loaded.";
+
+const KLARNA_CONFIG: PaymentMethodSelectorKlarnaConfig = {
+  sessionId: "session-1",
+  category: {
+    identifier: "pay_later",
+    name: "Pay later",
+    asset_urls: { descriptive: "", standard: "" },
+  },
+};
+
+type KlarnaLoadResult = {
+  show_form: boolean;
+  error?: { [key: string]: unknown };
+};
+type KlarnaLoadCallback = (result: KlarnaLoadResult) => void;
+
+let restoreClient: (() => void) | null = null;
+
+/**
+ * Swaps the SDK singleton's `klarna` instance for the duration of one test.
+ * Mirrors the override helper the element test uses — the embed reads the
+ * instance off the shared client at effect time, so there is nothing to inject
+ * through props.
+ */
+function useKlarnaInstance(klarna: unknown): void {
+  const descriptor = Object.getOwnPropertyDescriptor(checkoutClient, "klarna");
+
+  Object.defineProperty(checkoutClient, "klarna", {
+    configurable: true,
+    value: klarna,
+  });
+
+  restoreClient = () => {
+    if (descriptor) {
+      Object.defineProperty(checkoutClient, "klarna", descriptor);
+    } else {
+      delete (checkoutClient as Record<string, unknown>).klarna;
+    }
+  };
+}
+
+/** A Klarna SDK stub whose `Payments.load` is resolved by the test. */
+function klarnaStub() {
+  const calls: { container: HTMLElement; category: string }[] = [];
+  let respond: KlarnaLoadCallback | null = null;
+
+  return {
+    calls,
+    instance: {
+      Payments: {
+        load(
+          options: { container: HTMLElement; payment_method_category: string },
+          _data: unknown,
+          callback: KlarnaLoadCallback,
+        ) {
+          calls.push({
+            container: options.container,
+            category: options.payment_method_category,
+          });
+          respond = callback;
+        },
+      },
+    },
+    async resolveWith(result: KlarnaLoadResult): Promise<void> {
+      if (!respond) throw new Error("Klarna's load was never called.");
+      respond(result);
+      await flush();
+    },
+  };
+}
+
+function embed(
+  overrides: {
+    klarna?: false;
+    disabled?: boolean;
+    onAvailabilityChange?: (category: string, available: boolean) => void;
+  } = {},
+) {
+  return createElement(KlarnaOptionEmbed, {
+    option: optionWith({
+      id: "klarna",
+      klarna: overrides.klarna === false ? undefined : KLARNA_CONFIG,
+    }),
+    disabled: overrides.disabled,
+    onAvailabilityChange: overrides.onAvailabilityChange,
+    loadingMessage: LOADING_MESSAGE,
+    unavailableMessage: UNAVAILABLE_MESSAGE,
+    loadErrorMessage: LOAD_ERROR_MESSAGE,
+  });
+}
+
+function widgetIn(container: HTMLElement): HTMLElement {
+  const widget = container.querySelector<HTMLElement>(
+    '[data-klarna-widget="true"]',
+  );
+
+  if (!widget) throw new Error("The Klarna widget container did not render.");
+  return widget;
+}
+
+afterEach(() => {
+  restoreClient?.();
+  restoreClient = null;
+});
+
+describe("KlarnaOptionEmbed", () => {
+  it("renders nothing when the option carries no Klarna config", async () => {
+    const klarna = klarnaStub();
+    useKlarnaInstance(klarna.instance);
+
+    const mounted = await mountEmbed(embed({ klarna: false }));
+
+    expect(
+      mounted.container.querySelector('[data-klarna-widget="true"]'),
+    ).toBeNull();
+    expect(klarna.calls).toHaveLength(0);
+
+    await mounted.unmount();
+  });
+
+  it("shows the loading message and asks Klarna for the option's category", async () => {
+    const klarna = klarnaStub();
+    useKlarnaInstance(klarna.instance);
+
+    const mounted = await mountEmbed(embed());
+
+    expect(widgetIn(mounted.container).dataset.klarnaWidgetStatus).toBe(
+      "loading",
+    );
+    expect(mounted.container.textContent).toContain(LOADING_MESSAGE);
+    // Klarna renders one widget per category, so the wrong identifier here
+    // silently renders a different payment method than the shopper picked.
+    expect(klarna.calls).toEqual([
+      {
+        container: widgetIn(mounted.container),
+        category: KLARNA_CONFIG.category.identifier,
+      },
+    ]);
+
+    await mounted.unmount();
+  });
+
+  it("goes ready and reports the category as available when the form shows", async () => {
+    const klarna = klarnaStub();
+    useKlarnaInstance(klarna.instance);
+
+    const availability: [string, boolean][] = [];
+    const mounted = await mountEmbed(
+      embed({
+        onAvailabilityChange: (category, available) =>
+          availability.push([category, available]),
+      }),
+    );
+    await klarna.resolveWith({ show_form: true });
+
+    expect(widgetIn(mounted.container).dataset.klarnaWidgetStatus).toBe(
+      "ready",
+    );
+    expect(mounted.container.textContent).not.toContain(LOADING_MESSAGE);
+    expect(mounted.container.textContent).not.toContain(UNAVAILABLE_MESSAGE);
+    // The selector hides categories reported unavailable, so this callback is
+    // what keeps a dead Klarna option out of the list.
+    expect(availability).toEqual([[KLARNA_CONFIG.category.identifier, true]]);
+
+    await mounted.unmount();
+  });
+
+  // Klarna answers `show_form: false` when it declines the order, which is a
+  // normal outcome rather than a failure — the shopper needs to be told the
+  // option is unusable so they can pick another one.
+  it("goes unavailable when Klarna declines to show the form", async () => {
+    const klarna = klarnaStub();
+    useKlarnaInstance(klarna.instance);
+
+    const availability: [string, boolean][] = [];
+    const mounted = await mountEmbed(
+      embed({
+        onAvailabilityChange: (category, available) =>
+          availability.push([category, available]),
+      }),
+    );
+    await klarna.resolveWith({
+      show_form: false,
+      error: { invalid_fields: ["billing_address.postal_code"] },
+    });
+
+    expect(widgetIn(mounted.container).dataset.klarnaWidgetStatus).toBe(
+      "unavailable",
+    );
+    expect(mounted.container.textContent).toContain(UNAVAILABLE_MESSAGE);
+    expect(availability).toEqual([[KLARNA_CONFIG.category.identifier, false]]);
+
+    await mounted.unmount();
+  });
+
+  // The SDK instance is created during checkout initialization. If it never
+  // arrived, the embed has nothing to render into and says so instead of
+  // sitting on the loading message forever.
+  it("goes to the error state when the SDK instance is missing", async () => {
+    useKlarnaInstance(null);
+
+    const mounted = await mountEmbed(embed());
+
+    expect(widgetIn(mounted.container).dataset.klarnaWidgetStatus).toBe(
+      "error",
+    );
+    expect(mounted.container.textContent).toContain(LOAD_ERROR_MESSAGE);
+    expect(mounted.container.textContent).not.toContain(LOADING_MESSAGE);
+
+    await mounted.unmount();
+  });
+
+  it("goes to the error state when the SDK instance carries no Payments API", async () => {
+    useKlarnaInstance({});
+
+    const mounted = await mountEmbed(embed());
+
+    expect(widgetIn(mounted.container).dataset.klarnaWidgetStatus).toBe(
+      "error",
+    );
+    expect(mounted.container.textContent).toContain(LOAD_ERROR_MESSAGE);
+
+    await mounted.unmount();
+  });
+
+  it("goes to the error state when Klarna's load throws", async () => {
+    useKlarnaInstance({
+      Payments: {
+        load() {
+          throw new Error("Klarna SDK exploded.");
+        },
+      },
+    });
+
+    const mounted = await mountEmbed(embed());
+    await flush();
+
+    expect(widgetIn(mounted.container).dataset.klarnaWidgetStatus).toBe(
+      "error",
+    );
+    expect(mounted.container.textContent).toContain(LOAD_ERROR_MESSAGE);
+
+    await mounted.unmount();
+  });
+
+  // Klarna injects its iframe into the container it was handed. Leaving that
+  // behind on teardown would show a stale widget when the shopper comes back
+  // to the option, on top of whatever Klarna renders next.
+  it("empties the widget container on teardown", async () => {
+    const klarna = klarnaStub();
+    useKlarnaInstance(klarna.instance);
+
+    const mounted = await mountEmbed(embed());
+    const widget = widgetIn(mounted.container);
+    widget.append(document.createElement("iframe"));
+
+    await klarna.resolveWith({ show_form: true });
+    expect(widget.childElementCount).toBe(1);
+
+    await mounted.render(embed({ klarna: false }));
+
+    expect(widget.childElementCount).toBe(0);
+
+    await mounted.unmount();
+  });
+
+  it("marks the widget aria-disabled while the option is disabled", async () => {
+    const klarna = klarnaStub();
+    useKlarnaInstance(klarna.instance);
+
+    const mounted = await mountEmbed(embed({ disabled: true }));
+
+    expect(widgetIn(mounted.container).getAttribute("aria-disabled")).toBe(
+      "true",
+    );
+
+    await mounted.unmount();
+  });
+});

--- a/src/elements/foxy-payment-method-selector/embeds/purchase-order.test.ts
+++ b/src/elements/foxy-payment-method-selector/embeds/purchase-order.test.ts
@@ -1,0 +1,209 @@
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import type { PaymentController } from "../types";
+import PurchaseOrderOptionEmbed from "./purchase-order";
+import {
+  controllerSink,
+  mountEmbed,
+  optionWith,
+  rejection,
+  settled,
+  typeInto,
+} from "./test-utils";
+
+const LABEL = "Purchase order number";
+const PLACEHOLDER = "PO-000000";
+const REQUIRED_ERROR = "Enter a purchase order number.";
+const TOO_LONG_ERROR = "That purchase order number is too long.";
+const MAX_LENGTH = 32;
+
+type EmbedPropOverrides = {
+  optionId?: string;
+  disabled?: boolean;
+  onControllerReady?: (controller: PaymentController | null) => void;
+  maxLength?: number;
+};
+
+function embed(overrides: EmbedPropOverrides = {}) {
+  return createElement(PurchaseOrderOptionEmbed, {
+    option: optionWith({ id: overrides.optionId ?? "purchase-order" }),
+    disabled: overrides.disabled,
+    onControllerReady: overrides.onControllerReady,
+    label: LABEL,
+    placeholder: PLACEHOLDER,
+    requiredErrorMessage: REQUIRED_ERROR,
+    tooLongErrorMessage: TOO_LONG_ERROR,
+    maxLength: overrides.maxLength ?? MAX_LENGTH,
+  });
+}
+
+function inputIn(container: HTMLElement): HTMLInputElement {
+  const input = container.querySelector<HTMLInputElement>(
+    '[data-purchase-order-number="true"]',
+  );
+
+  if (!input) throw new Error("Purchase order number input did not render.");
+  return input;
+}
+
+describe("PurchaseOrderOptionEmbed", () => {
+  it("renders a labelled, required input wired to the field label", async () => {
+    const mounted = await mountEmbed(embed());
+
+    const input = inputIn(mounted.container);
+    const label = mounted.container.querySelector("label");
+
+    expect(input.required).toBe(true);
+    expect(input.maxLength).toBe(MAX_LENGTH);
+    expect(input.placeholder).toBe(PLACEHOLDER);
+    expect(label?.textContent).toBe(LABEL);
+    expect(label?.getAttribute("for")).toBe(input.id);
+
+    await mounted.unmount();
+  });
+
+  it("hands the host a controller on mount and clears it on unmount", async () => {
+    const sink = controllerSink();
+    const mounted = await mountEmbed(
+      embed({ onControllerReady: sink.onControllerReady }),
+    );
+
+    expect(sink.get().tokenize).toBeTypeOf("function");
+
+    await mounted.unmount();
+
+    // The selector reads a null controller as "this option cannot pay", so a
+    // missed teardown leaves it holding a controller for an unmounted field.
+    expect(sink.latest()).toBeNull();
+  });
+
+  it("rejects tokenization and shows the required error when the field is empty", async () => {
+    const sink = controllerSink();
+    const mounted = await mountEmbed(
+      embed({ onControllerReady: sink.onControllerReady }),
+    );
+
+    const error = await rejection(() => sink.get().tokenize());
+
+    expect(error.message).toBe(REQUIRED_ERROR);
+    expect(mounted.container.textContent).toContain(REQUIRED_ERROR);
+    expect(inputIn(mounted.container).getAttribute("aria-invalid")).toBe(
+      "true",
+    );
+
+    await mounted.unmount();
+  });
+
+  // Whitespace only looks filled in. The embed trims before testing for
+  // emptiness, so "   " has to fail the same way "" does.
+  it("treats a whitespace-only number as empty", async () => {
+    const sink = controllerSink();
+    const mounted = await mountEmbed(
+      embed({ onControllerReady: sink.onControllerReady }),
+    );
+
+    await typeInto(inputIn(mounted.container), "   ");
+    const error = await rejection(() => sink.get().tokenize());
+
+    expect(error.message).toBe(REQUIRED_ERROR);
+
+    await mounted.unmount();
+  });
+
+  // The input's own `maxLength` stops a shopper typing past the limit, so the
+  // length branch is only reachable through a value the browser did not cap —
+  // a paste on some engines, or a host that lowered `maxLength` after the fact.
+  it("rejects a number longer than maxLength", async () => {
+    const sink = controllerSink();
+    const mounted = await mountEmbed(
+      embed({ onControllerReady: sink.onControllerReady, maxLength: 4 }),
+    );
+
+    await typeInto(inputIn(mounted.container), "PO-12345");
+    const error = await rejection(() => sink.get().tokenize());
+
+    expect(error.message).toBe(TOO_LONG_ERROR);
+    expect(mounted.container.textContent).toContain(TOO_LONG_ERROR);
+
+    await mounted.unmount();
+  });
+
+  it("trims the number and returns a request id once it is valid", async () => {
+    const sink = controllerSink();
+    const mounted = await mountEmbed(
+      embed({ onControllerReady: sink.onControllerReady }),
+    );
+
+    await typeInto(inputIn(mounted.container), "  PO-123456  ");
+
+    const payload = (await settled(() => sink.get().tokenize())) as {
+      requestId: string;
+      purchaseOrderNumber: string;
+    };
+
+    expect(payload.purchaseOrderNumber).toBe("PO-123456");
+    expect(payload.requestId).toBeTypeOf("string");
+    expect(payload.requestId.length).toBeGreaterThan(0);
+
+    await mounted.unmount();
+  });
+
+  it("clears a shown error as soon as the number becomes valid", async () => {
+    const sink = controllerSink();
+    const mounted = await mountEmbed(
+      embed({ onControllerReady: sink.onControllerReady }),
+    );
+
+    await rejection(() => sink.get().tokenize());
+    expect(mounted.container.textContent).toContain(REQUIRED_ERROR);
+
+    await typeInto(inputIn(mounted.container), "PO-1");
+
+    expect(mounted.container.textContent).not.toContain(REQUIRED_ERROR);
+    expect(inputIn(mounted.container).getAttribute("aria-invalid")).toBe(
+      "false",
+    );
+
+    await mounted.unmount();
+  });
+
+  // The selector reuses one embed instance across options, so a number typed
+  // for one option must not travel to the next.
+  it("resets the number and the error when the option changes", async () => {
+    const sink = controllerSink();
+    const mounted = await mountEmbed(
+      embed({
+        onControllerReady: sink.onControllerReady,
+        optionId: "purchase-order-1",
+      }),
+    );
+
+    await typeInto(inputIn(mounted.container), "PO-111111");
+    await expect(settled(() => sink.get().tokenize())).resolves.toMatchObject({
+      purchaseOrderNumber: "PO-111111",
+    });
+
+    await mounted.render(
+      embed({
+        onControllerReady: sink.onControllerReady,
+        optionId: "purchase-order-2",
+      }),
+    );
+
+    expect(inputIn(mounted.container).value).toBe("");
+    expect((await rejection(() => sink.get().tokenize())).message).toBe(
+      REQUIRED_ERROR,
+    );
+
+    await mounted.unmount();
+  });
+
+  it("disables the input when the host disables the option", async () => {
+    const mounted = await mountEmbed(embed({ disabled: true }));
+
+    expect(inputIn(mounted.container).disabled).toBe(true);
+
+    await mounted.unmount();
+  });
+});

--- a/src/elements/foxy-payment-method-selector/embeds/stripe-card.test.ts
+++ b/src/elements/foxy-payment-method-selector/embeds/stripe-card.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { StripeCardElementOption } from "../stripe/card-option";
+import StripeCardEmbed from "./stripe-card";
+
+/**
+ * This file is only a re-export, but it is the module the selector lazy-loads
+ * for the Stripe Card Element option (`view.tsx`, `lazy(() => import(...))`).
+ * `React.lazy` resolves the module's *default* export and throws at render time
+ * if there is none, so dropping or renaming it breaks the option in the browser
+ * with no build error — the dynamic import hides the mismatch from the type
+ * system.
+ */
+describe("stripe-card embed module", () => {
+  it("default-exports the Stripe Card Element option", () => {
+    expect(StripeCardEmbed).toBe(StripeCardElementOption);
+  });
+
+  it("default-exports something React.lazy can render", () => {
+    expect(StripeCardEmbed).toBeTypeOf("function");
+  });
+});

--- a/src/elements/foxy-payment-method-selector/embeds/stripe-payment.test.ts
+++ b/src/elements/foxy-payment-method-selector/embeds/stripe-payment.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { StripePaymentElementOption } from "../stripe/payment-option";
+import StripePaymentEmbed from "./stripe-payment";
+
+/**
+ * This file is only a re-export, but it is the module the selector lazy-loads
+ * for the `stripe_v2` option (`view.tsx`, `lazy(() => import(...))`).
+ * `React.lazy` resolves the module's *default* export and throws at render time
+ * if there is none, so dropping or renaming it breaks the option in the browser
+ * with no build error — the dynamic import hides the mismatch from the type
+ * system.
+ */
+describe("stripe-payment embed module", () => {
+  it("default-exports the Stripe Payment Element option", () => {
+    expect(StripePaymentEmbed).toBe(StripePaymentElementOption);
+  });
+
+  it("default-exports something React.lazy can render", () => {
+    expect(StripePaymentEmbed).toBeTypeOf("function");
+  });
+
+  // The two Stripe embeds are separate options with separate SDK setups: the
+  // Card Element tokenizes a card, `stripe_v2` mounts deferred and confirms an
+  // intent the backend creates. A copy-paste in either re-export would point
+  // both option types at the same component.
+  it("is a different component from the Stripe Card Element embed", async () => {
+    const cardEmbed = (await import("./stripe-card")).default;
+
+    expect(StripePaymentEmbed).not.toBe(cardEmbed);
+  });
+});

--- a/src/elements/foxy-payment-method-selector/embeds/test-utils.ts
+++ b/src/elements/foxy-payment-method-selector/embeds/test-utils.ts
@@ -1,0 +1,168 @@
+import { act, createElement, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ThemeProvider } from "styled-components";
+import { defaultTheme } from "@foxy.io/design-system/theme";
+
+import type { PaymentController, PaymentMethodSelectorOption } from "../types";
+
+/**
+ * Embed tests render the React component directly instead of driving it through
+ * `foxy-payment-method-selector`. The element test already covers the happy
+ * paths end to end; what it cannot reach cheaply are the per-embed branches
+ * (missing SDK instance, teardown, prop fallbacks), which need control over the
+ * props the selector normally computes for itself.
+ *
+ * The `unit` vitest project only picks up `src/**\/*.test.ts`, so there is no
+ * JSX in these files — `createElement` throughout.
+ */
+
+// React only allows `act` outside a test renderer when this is set, and warns
+// on every update otherwise.
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+export type MountedEmbed = {
+  container: HTMLDivElement;
+  /** Re-renders a different tree inside the same root. */
+  render: (node: ReactNode) => Promise<void>;
+  unmount: () => Promise<void>;
+};
+
+function withTheme(node: ReactNode): ReactNode {
+  return createElement(
+    ThemeProvider,
+    { theme: { tokens: defaultTheme } },
+    node,
+  );
+}
+
+/**
+ * Mounts `node` under a `ThemeProvider` in a container attached to the
+ * document. Attached rather than detached because the embeds mount custom
+ * elements, which only upgrade once they are connected.
+ */
+export async function mountEmbed(node: ReactNode): Promise<MountedEmbed> {
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  const root: Root = createRoot(container);
+
+  await act(async () => {
+    root.render(withTheme(node));
+  });
+
+  return {
+    container,
+    render: async (next: ReactNode) => {
+      await act(async () => {
+        root.render(withTheme(next));
+      });
+    },
+    unmount: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+
+      container.remove();
+    },
+  };
+}
+
+/** Lets queued microtasks and the effects they schedule settle. */
+export async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/**
+ * Runs `work` and settles the React updates it causes. Anything that touches a
+ * mounted embed from outside React — dispatching an input event, calling a
+ * controller's `tokenize()` — goes through here, or React logs an "update was
+ * not wrapped in act(...)" error for every resulting state change.
+ */
+export async function settled<T>(work: () => T | Promise<T>): Promise<T> {
+  let result: T;
+
+  await act(async () => {
+    result = await work();
+  });
+
+  return result!;
+}
+
+/**
+ * Like {@link settled}, but for a call that is expected to reject: returns the
+ * rejection so the test can assert on it. `expect(...).rejects` cannot be used
+ * directly here because the rejection has to be caught inside `act`.
+ */
+export async function rejection(work: () => Promise<unknown>): Promise<Error> {
+  let caught: unknown;
+
+  await act(async () => {
+    try {
+      await work();
+    } catch (error) {
+      caught = error;
+    }
+  });
+
+  if (!(caught instanceof Error)) {
+    throw new Error(`Expected a rejection, got: ${String(caught)}`);
+  }
+
+  return caught;
+}
+
+/**
+ * Sets an input's value the way a shopper would. React reads the value off its
+ * own descriptor, so a plain `input.value = x` is invisible to the controlled
+ * component and its state never updates.
+ */
+export async function typeInto(
+  input: HTMLInputElement,
+  value: string,
+): Promise<void> {
+  await settled(() => {
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )?.set;
+
+    setter?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+/**
+ * Collects what an embed passes to `onControllerReady`. The embeds hand the
+ * controller out from an effect and replace it with `null` on teardown, so a
+ * plain variable would be null by the time a test wants to call it.
+ */
+export function controllerSink() {
+  let current: PaymentController | null = null;
+  let last: PaymentController | null | undefined;
+
+  return {
+    onControllerReady(next: PaymentController | null) {
+      last = next;
+      current = next ?? current;
+    },
+    /** The last controller handed out, or a failure if there was none. */
+    get(): PaymentController {
+      if (!current) throw new Error("The embed handed out no controller.");
+      return current;
+    },
+    /** The most recent value, including the `null` passed on teardown. */
+    latest(): PaymentController | null | undefined {
+      return last;
+    },
+  };
+}
+
+export function optionWith(
+  overrides: Partial<PaymentMethodSelectorOption>,
+): PaymentMethodSelectorOption {
+  return { id: "test-option", label: "Test option", ...overrides };
+}


### PR DESCRIPTION
https://linear.app/foxyio/issue/FX-176

Draft. Opened automatically; details are on the linked issue.