### PR TITLE
fix(elements): reflect type and mode when the assigned value is the default (FX-264) [agent]

### DIFF
--- a/src/elements/foxy-ach-field/element.test.ts
+++ b/src/elements/foxy-ach-field/element.test.ts
@@ -193,6 +193,54 @@ describe("AchFieldElement events", () => {
     vi.restoreAllMocks();
   });
 
+  // FX-264: the setter returned early when the assigned value already matched
+  // the element's state, before it reached `setAttribute`. `routing-number` is
+  // the default, so assigning it reflected nothing and the field stayed
+  // unreachable by `foxy-ach-field[type="routing-number"]`.
+  it("reflects type to an attribute even when the value is the element's default", () => {
+    const field = createField("routing-number");
+
+    expect(field.getAttribute("type")).toBe("routing-number");
+    expect(
+      document.querySelectorAll('foxy-ach-field[type="routing-number"]'),
+    ).toHaveLength(1);
+  });
+
+  it("reflects type before the element is connected", () => {
+    const field = document.createElement(
+      ACH_FIELD_ELEMENT_TAG,
+    ) as AchFieldElement;
+
+    field.type = "routing-number";
+
+    expect(field.isConnected).toBe(false);
+    expect(field.getAttribute("type")).toBe("routing-number");
+  });
+
+  it("keeps reflecting a type change away from and back to the default", () => {
+    const field = createField("routing-number");
+
+    field.type = "account-number";
+    expect(field.getAttribute("type")).toBe("account-number");
+    expect(field.type).toBe("account-number");
+
+    field.type = "routing-number";
+    expect(field.getAttribute("type")).toBe("routing-number");
+    expect(field.type).toBe("routing-number");
+  });
+
+  // An unrecognised value falls back to the default, which is exactly the case
+  // the old early return swallowed: state and attribute both have to end up on
+  // the fallback.
+  it("reflects the fallback type when the assigned value is not a field name", () => {
+    const field = createField("account-number");
+
+    field.type = "not-a-field" as AchFieldElement["type"];
+
+    expect(field.type).toBe("routing-number");
+    expect(field.getAttribute("type")).toBe("routing-number");
+  });
+
   it("dispatches change only for field instances whose values changed", () => {
     const routing = createField("routing-number");
     const account = createField("account-number", routing.group);

--- a/src/elements/foxy-ach-field/element.ts
+++ b/src/elements/foxy-ach-field/element.ts
@@ -640,9 +640,16 @@ export class AchFieldElement extends ThemeableHTMLElement {
 
   set type(value: AchHostedFieldName) {
     const normalized = isAchFieldName(value) ? value : "routing-number";
-    if (normalized === this._type) return;
+    const changed = normalized !== this._type;
 
-    this._type = normalized;
+    if (changed) this._type = normalized;
+
+    // Reflected even when the state did not change. `routing-number` is this
+    // element's own default, so assigning it is a no-op for state — and
+    // returning here would leave the field with no `type` attribute at all,
+    // invisible to attribute selectors, CSS and devtools. Assigned before the
+    // write so attributeChangedCallback sees the state it is about to be told
+    // about and stops.
     if (this.getAttribute(TYPE_ATTRIBUTE) !== normalized) {
       this.setAttribute(TYPE_ATTRIBUTE, normalized);
     }

--- a/src/elements/foxy-payment-card-field/element.test.ts
+++ b/src/elements/foxy-payment-card-field/element.test.ts
@@ -239,7 +239,10 @@ describe("PaymentCardFieldElement", () => {
     const element = document.createElement(
       PAYMENT_CARD_FIELD_ELEMENT_TAG,
     ) as PaymentCardFieldElement;
-    element.style.setProperty("--font-body", "400 1rem/1.25 Figtree, sans-serif");
+    element.style.setProperty(
+      "--font-body",
+      "400 1rem/1.25 Figtree, sans-serif",
+    );
     element.style.setProperty("--size-control", "4rem");
     document.body.append(element);
 
@@ -259,7 +262,9 @@ describe("PaymentCardFieldElement", () => {
       window.location.origin,
     );
     expect(url.searchParams.get("theme_font_sans")).toBe("Figtree, sans-serif");
-    expect(url.searchParams.get("theme_input_height")).toBe(`${expectedHeightPx}px`);
+    expect(url.searchParams.get("theme_input_height")).toBe(
+      `${expectedHeightPx}px`,
+    );
   });
 
   it("falls back to card mode for unsupported mode values", () => {
@@ -271,6 +276,67 @@ describe("PaymentCardFieldElement", () => {
 
     expect(element.mode).toBe("card");
     expect(element.getAttribute("mode")).toBe("card");
+  });
+
+  // FX-264: the setter returned early when the assigned value already matched
+  // the element's state, before it reached `setAttribute`. `card` is the
+  // default, so assigning it reflected nothing and the field stayed unreachable
+  // by `foxy-payment-card-field[mode="card"]`.
+  it("reflects mode to an attribute even when the value is the element's default", () => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+    document.body.append(element);
+
+    element.mode = "card";
+
+    expect(element.getAttribute("mode")).toBe("card");
+    expect(
+      document.querySelectorAll('foxy-payment-card-field[mode="card"]'),
+    ).toHaveLength(1);
+  });
+
+  it("reflects mode before the element is connected", () => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+
+    element.mode = "card";
+
+    expect(element.isConnected).toBe(false);
+    expect(element.getAttribute("mode")).toBe("card");
+  });
+
+  // Reflecting the no-op assignment must not cost a second iframe mount: the
+  // attribute write reaches attributeChangedCallback, which remounts whenever
+  // it sees a genuinely new mode.
+  it("does not remount the iframe when mode is reassigned its current value", () => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+    document.body.append(element);
+
+    const before = element.shadowRoot?.querySelector("iframe");
+    expect(before).toBeTruthy();
+
+    element.mode = "card";
+
+    expect(element.shadowRoot?.querySelector("iframe")).toBe(before);
+  });
+
+  it("keeps reflecting a mode change away from and back to the default", () => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+    document.body.append(element);
+
+    element.mode = "card_csc";
+    expect(element.getAttribute("mode")).toBe("card_csc");
+    expect(element.mode).toBe("card_csc");
+
+    element.mode = "card";
+    expect(element.getAttribute("mode")).toBe("card");
+    expect(element.mode).toBe("card");
   });
 
   it("uses VITE_EMBED_ORIGIN to build the iframe URL", () => {

--- a/src/elements/foxy-payment-card-field/element.ts
+++ b/src/elements/foxy-payment-card-field/element.ts
@@ -313,12 +313,21 @@ export class PaymentCardFieldElement extends ThemeableHTMLElement {
 
   set mode(value: PaymentCardFieldMode) {
     const normalized = normalizeMode(value);
-    if (this._mode === normalized) return;
+    const changed = this._mode !== normalized;
 
-    this._mode = normalized;
+    if (changed) this._mode = normalized;
+
+    // Reflected even when the state did not change. `card` is this element's
+    // own default, so assigning it is a no-op for state — and returning here
+    // would leave the field with no `mode` attribute at all, invisible to
+    // attribute selectors, CSS and devtools. Assigned before the write so
+    // attributeChangedCallback sees the state it is about to be told about and
+    // stops, which is what keeps the iframe from mounting twice.
     if (this.getAttribute(MODE_ATTRIBUTE) !== normalized) {
       this.setAttribute(MODE_ATTRIBUTE, normalized);
     }
+
+    if (!changed) return;
 
     this._syncAggregateValidity();
     if (this.isConnected) this._mountIframe();

--- a/src/elements/foxy-payment-method-selector/embeds/ach-hosted.test.ts
+++ b/src/elements/foxy-payment-method-selector/embeds/ach-hosted.test.ts
@@ -214,21 +214,24 @@ describe("AchOptionEmbed", () => {
     await mounted.unmount();
   });
 
-  // Documents current behaviour rather than endorsing it: `foxy-ach-field`'s
-  // `type` setter returns early when the value already matches, and the field
-  // defaults to `routing-number`, so React assigning that same value never
-  // reaches `setAttribute`. The result is one field out of four with no `type`
-  // attribute, which an attribute selector cannot see. Update this test when
-  // the reflection is made unconditional; do not delete it.
-  it("reflects type to an attribute for every field except the default one", async () => {
+  // The routing-number field is the one that used to be missing its attribute:
+  // it is `foxy-ach-field`'s default type, and the setter returned early on a
+  // matching value before it reached `setAttribute`, so React assigning that
+  // same value reflected nothing (FX-264).
+  it("reflects type to an attribute for every field, including the default one", async () => {
     const mounted = await mountEmbed(embed());
 
     expect(
-      fieldIn(mounted.container, "routing-number").hasAttribute("type"),
-    ).toBe(false);
+      fieldIn(mounted.container, "routing-number").getAttribute("type"),
+    ).toBe("routing-number");
     expect(
       fieldIn(mounted.container, "account-number").getAttribute("type"),
     ).toBe("account-number");
+    // The reason the attribute matters: this is how a stylesheet or a test
+    // reaches one specific field.
+    expect(
+      mounted.container.querySelectorAll("foxy-ach-field[type]"),
+    ).toHaveLength(4);
 
     await mounted.unmount();
   });


### PR DESCRIPTION
https://linear.app/foxyio/issue/FX-264

Draft. Opened automatically; details are on the linked issue.