### PR TITLE
feat(elements): expose ValidityState on the hosted fields (FX-265) [agent]

### DIFF
--- a/src/elements/foxy-ach-field/element.test.ts
+++ b/src/elements/foxy-ach-field/element.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ALWAYS_VALID } from "@/lib/validity";
 import { THEME_PROPERTY_TO_ATTRIBUTE } from "@/lib/theme-mixin";
 import { deriveInputMetrics } from "@/lib/theme-attribute-sync";
 import { defaultTheme } from "@foxy.io/design-system/theme";
@@ -15,6 +16,9 @@ type FakeInternals = {
   reportValidity: ReturnType<typeof vi.fn>;
   setValidity: ReturnType<typeof vi.fn>;
   states: Set<string>;
+  validationMessage: string;
+  validity: ValidityState;
+  willValidate: boolean;
 };
 
 type HostedFieldState = {
@@ -37,7 +41,20 @@ function installFakeInternals(): void {
         reportValidity: vi.fn(() => true),
         setValidity: vi.fn(),
         states: new Set<string>(),
+        validationMessage: "",
+        validity: { ...ALWAYS_VALID },
+        willValidate: true,
       };
+
+      // Record what `setValidity` was given, so the element's `validity` and
+      // `validationMessage` getters have real internals state to forward.
+      internals.setValidity.mockImplementation(
+        (flags?: ValidityStateFlags, message?: string) => {
+          const valid = !flags || Object.keys(flags).length === 0;
+          internals.validity = { ...ALWAYS_VALID, ...flags, valid };
+          internals.validationMessage = valid ? "" : (message ?? "");
+        },
+      );
       internalsByElement.set(this, internals);
       return internals;
     },
@@ -301,6 +318,59 @@ describe("AchFieldElement events", () => {
     );
 
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes the failing constraint through validity and validationMessage", () => {
+    const routing = createField("routing-number");
+
+    // `ElementInternals` keeps `validity` to itself, so without the element
+    // forwarding it a consumer can only learn that something is wrong, not
+    // which constraint failed -- and cannot substitute its own localized copy.
+    // A pristine field is already incomplete, so it starts out valueMissing.
+    expect(routing.validity.valueMissing).toBe(true);
+    expect(routing.validity.valid).toBe(false);
+
+    dispatchHostedChange(routing, {
+      "routing-number": { complete: false, empty: true, errorCode: null },
+    });
+
+    expect(routing.validity.valueMissing).toBe(true);
+    expect(routing.validity.badInput).toBe(false);
+    expect(routing.validity.valid).toBe(false);
+    expect(routing.validationMessage).toBe("Please complete routing number.");
+
+    dispatchHostedChange(routing, {
+      "routing-number": {
+        complete: true,
+        empty: false,
+        errorCode: "invalid_routing_number",
+      },
+    });
+
+    // The distinction is the point: a consumer can render one message for a
+    // blank field and another for a malformed one.
+    expect(routing.validity.badInput).toBe(true);
+    expect(routing.validity.valueMissing).toBe(false);
+    expect(routing.validationMessage).toBe("Please check routing number.");
+
+    dispatchHostedChange(routing, {
+      "routing-number": { complete: true, empty: false, errorCode: null },
+    });
+
+    expect(routing.validity.valid).toBe(true);
+    expect(routing.validationMessage).toBe("");
+  });
+
+  it("reports valid when element internals are unavailable", () => {
+    const routing = createField("routing-number");
+    // Mirrors `checkValidity()`, which already answers true without internals.
+    Reflect.set(routing, "_internals", null);
+
+    expect(routing.validity).toEqual(ALWAYS_VALID);
+    expect(routing.validity.valid).toBe(true);
+    expect(routing.validationMessage).toBe("");
+    expect(routing.willValidate).toBe(false);
+    expect(routing.checkValidity()).toBe(true);
   });
 
   it("uses built-in validity flags for incomplete and invalid hosted state", () => {

--- a/src/elements/foxy-ach-field/element.ts
+++ b/src/elements/foxy-ach-field/element.ts
@@ -1,5 +1,6 @@
 import type { AchHostedFieldsPublicState } from "@foxy.io/sdk/checkout";
 import type { AchHostedFieldsTokenizeErrorCode } from "@foxy.io/sdk/checkout";
+import { ALWAYS_VALID } from "@/lib/validity";
 import {
   getThemeDefinitionsByAttributeNames,
   ThemeMixin,
@@ -788,6 +789,20 @@ export class AchFieldElement extends ThemeableHTMLElement {
         id: normalizedRequestId,
       });
     });
+  }
+
+  // `ElementInternals` does not mirror these onto the element, so a consumer
+  // reading which constraint failed needs them forwarded explicitly.
+  get validity(): ValidityState {
+    return this._internals?.validity ?? ALWAYS_VALID;
+  }
+
+  get validationMessage(): string {
+    return this._internals?.validationMessage ?? "";
+  }
+
+  get willValidate(): boolean {
+    return this._internals?.willValidate ?? false;
   }
 
   checkValidity(): boolean {

--- a/src/elements/foxy-payment-card-field/element.test.ts
+++ b/src/elements/foxy-payment-card-field/element.test.ts
@@ -473,12 +473,10 @@ describe("PaymentCardFieldElement", () => {
     expect(element.validity.valid).toBe(false);
     expect(element.validationMessage).toBe("Card details are invalid.");
 
-    // NOTE: every embed validation code collapses onto `customError` here,
-    // unlike the ACH field, which distinguishes valueMissing from badInput.
-    // The embed's own code is more specific than what `validity` can express
-    // today -- mapping the two is a separate change from exposing them.
-    expect(element.validity.customError).toBe(true);
-    expect(element.validity.valueMissing).toBe(false);
+    // The embed's code decides the constraint, so a consumer can tell this
+    // apart from a malformed value and word the two differently.
+    expect(element.validity.valueMissing).toBe(true);
+    expect(element.validity.customError).toBe(false);
 
     privateElement._handlePortMessage({
       data: JSON.stringify({
@@ -491,6 +489,64 @@ describe("PaymentCardFieldElement", () => {
 
     expect(element.validity.valid).toBe(true);
     expect(element.validationMessage).toBe("");
+  });
+
+  // `card_brand_unsupported` and `invalid_state` are business rules with no
+  // native constraint to match, so they stay on customError by design.
+  it.each([
+    ["value_missing", "valueMissing"],
+    ["pattern_mismatch", "patternMismatch"],
+    ["range_underflow", "rangeUnderflow"],
+    ["card_brand_unsupported", "customError"],
+    ["invalid_state", "customError"],
+  ] as const)("maps the %s embed code onto %s", (code, flag) => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+    document.body.append(element);
+
+    const internals = getInternals(element);
+    const privateElement = element as unknown as {
+      _handlePortMessage: (event: MessageEvent<string>) => void;
+    };
+
+    privateElement._handlePortMessage({
+      data: JSON.stringify({
+        type: "validation",
+        field: "form",
+        valid: false,
+        code,
+      }),
+    } as MessageEvent<string>);
+
+    expect(internals.setValidity).toHaveBeenLastCalledWith(
+      { [flag]: true },
+      "Card details are invalid.",
+    );
+    expect(element.validity[flag]).toBe(true);
+    expect(element.validity.valid).toBe(false);
+  });
+
+  it("falls back to customError when an invalid field sends no code", () => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+    document.body.append(element);
+
+    const internals = getInternals(element);
+    const privateElement = element as unknown as {
+      _handlePortMessage: (event: MessageEvent<string>) => void;
+    };
+
+    privateElement._handlePortMessage({
+      data: JSON.stringify({ type: "validation", field: "form", valid: false }),
+    } as MessageEvent<string>);
+
+    expect(internals.setValidity).toHaveBeenLastCalledWith(
+      { customError: true },
+      "Card details are invalid.",
+    );
+    expect(element.validity.customError).toBe(true);
   });
 
   it("reports valid when element internals are unavailable", () => {
@@ -529,7 +585,7 @@ describe("PaymentCardFieldElement", () => {
     } as MessageEvent<string>);
 
     expect(internals.setValidity).toHaveBeenLastCalledWith(
-      { customError: true },
+      { patternMismatch: true },
       "Please enter a valid card number.",
     );
 
@@ -538,7 +594,7 @@ describe("PaymentCardFieldElement", () => {
 
     element.disabled = false;
     expect(internals.setValidity).toHaveBeenLastCalledWith(
-      { customError: true },
+      { patternMismatch: true },
       "Please enter a valid card number.",
     );
   });

--- a/src/elements/foxy-payment-card-field/element.test.ts
+++ b/src/elements/foxy-payment-card-field/element.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ALWAYS_VALID } from "@/lib/validity";
 import {
   THEME_ATTRIBUTE_NAMES,
   THEME_PROPERTY_TO_ATTRIBUTE,
@@ -15,6 +16,9 @@ type FakeInternals = {
   reportValidity: ReturnType<typeof vi.fn>;
   setValidity: ReturnType<typeof vi.fn>;
   states: Set<string>;
+  validationMessage: string;
+  validity: ValidityState;
+  willValidate: boolean;
 };
 
 const internalsByElement = new WeakMap<HTMLElement, FakeInternals>();
@@ -29,7 +33,20 @@ function installFakeInternals(): void {
         reportValidity: vi.fn(() => true),
         setValidity: vi.fn(),
         states: new Set<string>(),
+        validationMessage: "",
+        validity: { ...ALWAYS_VALID },
+        willValidate: true,
       };
+
+      // Record what `setValidity` was given, so the element's `validity` and
+      // `validationMessage` getters have real internals state to forward.
+      internals.setValidity.mockImplementation(
+        (flags?: ValidityStateFlags, message?: string) => {
+          const valid = !flags || Object.keys(flags).length === 0;
+          internals.validity = { ...ALWAYS_VALID, ...flags, valid };
+          internals.validationMessage = valid ? "" : (message ?? "");
+        },
+      );
       internalsByElement.set(this, internals);
       return internals;
     },
@@ -429,6 +446,66 @@ describe("PaymentCardFieldElement", () => {
       token: "tok_test_card",
       requestId: "card-request-duplicate",
     });
+  });
+
+  it("exposes validity and validationMessage to consumers", () => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+    document.body.append(element);
+
+    const privateElement = element as unknown as {
+      _handlePortMessage: (event: MessageEvent<string>) => void;
+    };
+
+    expect(element.validity.valid).toBe(true);
+    expect(element.validationMessage).toBe("");
+
+    privateElement._handlePortMessage({
+      data: JSON.stringify({
+        type: "validation",
+        field: "form",
+        valid: false,
+        code: "value_missing",
+      }),
+    } as MessageEvent<string>);
+
+    expect(element.validity.valid).toBe(false);
+    expect(element.validationMessage).toBe("Card details are invalid.");
+
+    // NOTE: every embed validation code collapses onto `customError` here,
+    // unlike the ACH field, which distinguishes valueMissing from badInput.
+    // The embed's own code is more specific than what `validity` can express
+    // today -- mapping the two is a separate change from exposing them.
+    expect(element.validity.customError).toBe(true);
+    expect(element.validity.valueMissing).toBe(false);
+
+    privateElement._handlePortMessage({
+      data: JSON.stringify({
+        type: "validation",
+        field: "form",
+        valid: true,
+        code: null,
+      }),
+    } as MessageEvent<string>);
+
+    expect(element.validity.valid).toBe(true);
+    expect(element.validationMessage).toBe("");
+  });
+
+  it("reports valid when element internals are unavailable", () => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+    document.body.append(element);
+
+    // Mirrors `checkValidity()`, which already answers true without internals.
+    Reflect.set(element, "_internals", null);
+
+    expect(element.validity).toEqual(ALWAYS_VALID);
+    expect(element.validationMessage).toBe("");
+    expect(element.willValidate).toBe(false);
+    expect(element.checkValidity()).toBe(true);
   });
 
   it("restores previously known invalid state when re-enabled", () => {

--- a/src/elements/foxy-payment-card-field/element.ts
+++ b/src/elements/foxy-payment-card-field/element.ts
@@ -192,6 +192,25 @@ function toValidationMessage(
   return "Card details are invalid.";
 }
 
+// The embed already knows why a field failed, so report it as the matching
+// constraint rather than collapsing everything onto customError. That is what
+// lets a consumer reading `validity` tell a blank field from a malformed one
+// and pick its own wording. `card_brand_unsupported` and `invalid_state` have
+// no native equivalent -- they are business rules, not format problems -- so
+// they stay customError, as does an invalid field that sent no code.
+function toValidityFlags(code: EmbedValidationCode | null): ValidityStateFlags {
+  switch (code) {
+    case "value_missing":
+      return { valueMissing: true };
+    case "pattern_mismatch":
+      return { patternMismatch: true };
+    case "range_underflow":
+      return { rangeUnderflow: true };
+    default:
+      return { customError: true };
+  }
+}
+
 function toErrorMessage(code: CardEmbedTokenizeErrorCode): string {
   switch (code) {
     case "invalid_state":
@@ -242,7 +261,7 @@ export class PaymentCardFieldElement extends ThemeableHTMLElement {
   private _ready = false;
   private _fieldValidation = new Map<
     EmbedValidationField,
-    { valid: boolean; message: string | null }
+    { valid: boolean; message: string | null; code: EmbedValidationCode | null }
   >();
   private _focused = false;
   private _touched = false;
@@ -886,21 +905,26 @@ export class PaymentCardFieldElement extends ThemeableHTMLElement {
     )
       return;
 
-    const message =
+    const validationCode =
       valid || typeof code !== "string"
         ? null
-        : toValidationMessage(field, code as EmbedValidationCode);
-    this._fieldValidation.set(field, { valid, message });
+        : (code as EmbedValidationCode);
+    const message = toValidationMessage(field, validationCode);
+    this._fieldValidation.set(field, { valid, message, code: validationCode });
 
     if (field === "form") {
-      this._updateFormValidity(valid, message);
+      this._updateFormValidity(valid, message, validationCode);
       return;
     }
 
     this._syncAggregateValidity();
   }
 
-  private _updateFormValidity(valid: boolean, message: string | null): void {
+  private _updateFormValidity(
+    valid: boolean,
+    message: string | null,
+    code: EmbedValidationCode | null,
+  ): void {
     this._invalid = !valid;
     this._syncPublicStates();
 
@@ -912,7 +936,7 @@ export class PaymentCardFieldElement extends ThemeableHTMLElement {
     }
 
     this._internals.setValidity(
-      { customError: true },
+      toValidityFlags(code),
       message?.trim() || "Card details are invalid.",
     );
   }
@@ -946,17 +970,18 @@ export class PaymentCardFieldElement extends ThemeableHTMLElement {
         ): state is {
           valid: boolean;
           message: string | null;
+          code: EmbedValidationCode | null;
         } => state !== undefined,
       );
     const invalid = activeStates.find((state) => !state.valid);
 
     if (invalid) {
-      this._updateFormValidity(false, invalid.message ?? null);
+      this._updateFormValidity(false, invalid.message ?? null, invalid.code);
       return;
     }
 
     if (activeStates.length > 0) {
-      this._updateFormValidity(true, null);
+      this._updateFormValidity(true, null, null);
       return;
     }
 
@@ -964,6 +989,7 @@ export class PaymentCardFieldElement extends ThemeableHTMLElement {
     this._updateFormValidity(
       formState?.valid ?? true,
       formState?.message ?? null,
+      formState?.code ?? null,
     );
   }
 

--- a/src/elements/foxy-payment-card-field/element.ts
+++ b/src/elements/foxy-payment-card-field/element.ts
@@ -1,5 +1,6 @@
 import type { CardEmbedTokenizeErrorCode } from "@foxy.io/sdk/checkout";
 import { getRequiredEnvVar } from "@/lib/required-env";
+import { ALWAYS_VALID } from "@/lib/validity";
 import {
   THEME_DEFINITION_BY_ATTRIBUTE,
   ThemeMixin,
@@ -407,6 +408,20 @@ export class PaymentCardFieldElement extends ThemeableHTMLElement {
 
   formDisabledCallback(disabled: boolean): void {
     this.disabled = disabled;
+  }
+
+  // `ElementInternals` does not mirror these onto the element, so a consumer
+  // reading which constraint failed needs them forwarded explicitly.
+  get validity(): ValidityState {
+    return this._internals?.validity ?? ALWAYS_VALID;
+  }
+
+  get validationMessage(): string {
+    return this._internals?.validationMessage ?? "";
+  }
+
+  get willValidate(): boolean {
+    return this._internals?.willValidate ?? false;
   }
 
   checkValidity(): boolean {

--- a/src/lib/validity.ts
+++ b/src/lib/validity.ts
@@ -1,0 +1,19 @@
+// `attachInternals` is missing in a few environments, and the form-associated
+// elements already treat that as "nothing to validate" by returning true from
+// `checkValidity()`. A `validity` getter has to answer with an object, not a
+// boolean, so give it the same meaning: every constraint satisfied. Returning
+// `undefined` instead would push a null check onto every consumer and diverge
+// from the native form control surface these elements mirror.
+export const ALWAYS_VALID: ValidityState = Object.freeze({
+  badInput: false,
+  customError: false,
+  patternMismatch: false,
+  rangeOverflow: false,
+  rangeUnderflow: false,
+  stepMismatch: false,
+  tooLong: false,
+  tooShort: false,
+  typeMismatch: false,
+  valid: true,
+  valueMissing: false,
+});


### PR DESCRIPTION
https://linear.app/foxyio/issue/FX-265

Draft. Opened automatically; details are on the linked issue.