### PR TITLE
feat(payment-card-field): map embed validation codes onto validity flags (FX-266) [agent]

### DIFF
--- a/src/elements/foxy-payment-card-field/element.test.ts
+++ b/src/elements/foxy-payment-card-field/element.test.ts
@@ -473,12 +473,10 @@ describe("PaymentCardFieldElement", () => {
     expect(element.validity.valid).toBe(false);
     expect(element.validationMessage).toBe("Card details are invalid.");
 
-    // NOTE: every embed validation code collapses onto `customError` here,
-    // unlike the ACH field, which distinguishes valueMissing from badInput.
-    // The embed's own code is more specific than what `validity` can express
-    // today -- mapping the two is a separate change from exposing them.
-    expect(element.validity.customError).toBe(true);
-    expect(element.validity.valueMissing).toBe(false);
+    // The embed's code decides the constraint, so a consumer can tell this
+    // apart from a malformed value and word the two differently.
+    expect(element.validity.valueMissing).toBe(true);
+    expect(element.validity.customError).toBe(false);
 
     privateElement._handlePortMessage({
       data: JSON.stringify({
@@ -491,6 +489,64 @@ describe("PaymentCardFieldElement", () => {
 
     expect(element.validity.valid).toBe(true);
     expect(element.validationMessage).toBe("");
+  });
+
+  // `card_brand_unsupported` and `invalid_state` are business rules with no
+  // native constraint to match, so they stay on customError by design.
+  it.each([
+    ["value_missing", "valueMissing"],
+    ["pattern_mismatch", "patternMismatch"],
+    ["range_underflow", "rangeUnderflow"],
+    ["card_brand_unsupported", "customError"],
+    ["invalid_state", "customError"],
+  ] as const)("maps the %s embed code onto %s", (code, flag) => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+    document.body.append(element);
+
+    const internals = getInternals(element);
+    const privateElement = element as unknown as {
+      _handlePortMessage: (event: MessageEvent<string>) => void;
+    };
+
+    privateElement._handlePortMessage({
+      data: JSON.stringify({
+        type: "validation",
+        field: "form",
+        valid: false,
+        code,
+      }),
+    } as MessageEvent<string>);
+
+    expect(internals.setValidity).toHaveBeenLastCalledWith(
+      { [flag]: true },
+      "Card details are invalid.",
+    );
+    expect(element.validity[flag]).toBe(true);
+    expect(element.validity.valid).toBe(false);
+  });
+
+  it("falls back to customError when an invalid field sends no code", () => {
+    const element = document.createElement(
+      PAYMENT_CARD_FIELD_ELEMENT_TAG,
+    ) as PaymentCardFieldElement;
+    document.body.append(element);
+
+    const internals = getInternals(element);
+    const privateElement = element as unknown as {
+      _handlePortMessage: (event: MessageEvent<string>) => void;
+    };
+
+    privateElement._handlePortMessage({
+      data: JSON.stringify({ type: "validation", field: "form", valid: false }),
+    } as MessageEvent<string>);
+
+    expect(internals.setValidity).toHaveBeenLastCalledWith(
+      { customError: true },
+      "Card details are invalid.",
+    );
+    expect(element.validity.customError).toBe(true);
   });
 
   it("reports valid when element internals are unavailable", () => {
@@ -529,7 +585,7 @@ describe("PaymentCardFieldElement", () => {
     } as MessageEvent<string>);
 
     expect(internals.setValidity).toHaveBeenLastCalledWith(
-      { customError: true },
+      { patternMismatch: true },
       "Please enter a valid card number.",
     );
 
@@ -538,7 +594,7 @@ describe("PaymentCardFieldElement", () => {
 
     element.disabled = false;
     expect(internals.setValidity).toHaveBeenLastCalledWith(
-      { customError: true },
+      { patternMismatch: true },
       "Please enter a valid card number.",
     );
   });

--- a/src/elements/foxy-payment-card-field/element.ts
+++ b/src/elements/foxy-payment-card-field/element.ts
@@ -192,6 +192,25 @@ function toValidationMessage(
   return "Card details are invalid.";
 }
 
+// The embed already knows why a field failed, so report it as the matching
+// constraint rather than collapsing everything onto customError. That is what
+// lets a consumer reading `validity` tell a blank field from a malformed one
+// and pick its own wording. `card_brand_unsupported` and `invalid_state` have
+// no native equivalent -- they are business rules, not format problems -- so
+// they stay customError, as does an invalid field that sent no code.
+function toValidityFlags(code: EmbedValidationCode | null): ValidityStateFlags {
+  switch (code) {
+    case "value_missing":
+      return { valueMissing: true };
+    case "pattern_mismatch":
+      return { patternMismatch: true };
+    case "range_underflow":
+      return { rangeUnderflow: true };
+    default:
+      return { customError: true };
+  }
+}
+
 function toErrorMessage(code: CardEmbedTokenizeErrorCode): string {
   switch (code) {
     case "invalid_state":
@@ -242,7 +261,7 @@ export class PaymentCardFieldElement extends ThemeableHTMLElement {
   private _ready = false;
   private _fieldValidation = new Map<
     EmbedValidationField,
-    { valid: boolean; message: string | null }
+    { valid: boolean; message: string | null; code: EmbedValidationCode | null }
   >();
   private _focused = false;
   private _touched = false;
@@ -886,21 +905,26 @@ export class PaymentCardFieldElement extends ThemeableHTMLElement {
     )
       return;
 
-    const message =
+    const validationCode =
       valid || typeof code !== "string"
         ? null
-        : toValidationMessage(field, code as EmbedValidationCode);
-    this._fieldValidation.set(field, { valid, message });
+        : (code as EmbedValidationCode);
+    const message = toValidationMessage(field, validationCode);
+    this._fieldValidation.set(field, { valid, message, code: validationCode });
 
     if (field === "form") {
-      this._updateFormValidity(valid, message);
+      this._updateFormValidity(valid, message, validationCode);
       return;
     }
 
     this._syncAggregateValidity();
   }
 
-  private _updateFormValidity(valid: boolean, message: string | null): void {
+  private _updateFormValidity(
+    valid: boolean,
+    message: string | null,
+    code: EmbedValidationCode | null,
+  ): void {
     this._invalid = !valid;
     this._syncPublicStates();
 
@@ -912,7 +936,7 @@ export class PaymentCardFieldElement extends ThemeableHTMLElement {
     }
 
     this._internals.setValidity(
-      { customError: true },
+      toValidityFlags(code),
       message?.trim() || "Card details are invalid.",
     );
   }
@@ -946,17 +970,18 @@ export class PaymentCardFieldElement extends ThemeableHTMLElement {
         ): state is {
           valid: boolean;
           message: string | null;
+          code: EmbedValidationCode | null;
         } => state !== undefined,
       );
     const invalid = activeStates.find((state) => !state.valid);
 
     if (invalid) {
-      this._updateFormValidity(false, invalid.message ?? null);
+      this._updateFormValidity(false, invalid.message ?? null, invalid.code);
       return;
     }
 
     if (activeStates.length > 0) {
-      this._updateFormValidity(true, null);
+      this._updateFormValidity(true, null, null);
       return;
     }
 
@@ -964,6 +989,7 @@ export class PaymentCardFieldElement extends ThemeableHTMLElement {
     this._updateFormValidity(
       formState?.valid ?? true,
       formState?.message ?? null,
+      formState?.code ?? null,
     );
   }
 


### PR DESCRIPTION
https://linear.app/foxyio/issue/FX-266

Draft. Opened automatically; details are on the linked issue.